### PR TITLE
Refactor protobuf enum generation

### DIFF
--- a/openapiart/openapiart.py
+++ b/openapiart/openapiart.py
@@ -48,11 +48,19 @@ class OpenApiArt(object):
         self._api_files = api_files
         self._bundle()
         self._get_license()
+        self._get_info()
         self._document()
         self._generate()
 
     def _get_license(self):
         try:
+            self._license = "License: {}".format(
+                self._bundler._content["info"]["license"]["url"]
+            )
+            return
+            # currently license URL returns an HTML and not solely license text
+            # hence skipping this part unless we come across a better way to
+            # parse licenses
             response = requests.request("GET", self._bundler._content["info"]["license"]["url"])
             if response.ok:
                 self._license = response.text
@@ -60,6 +68,15 @@ class OpenApiArt(object):
                 raise Exception(response.text)
         except Exception as e:
             self._license = "OpenAPI info.license.url error [{}]".format(e)
+
+    def _get_info(self):
+        try:
+            self._info = "{} {}".format(
+                self._bundler._content["info"]["title"],
+                self._bundler._content["info"]["version"]
+            )
+        except Exception as e:
+            self._info = "OpenAPI info error [{}]".format(e)
 
     def _bundle(self):
         # bundle the yaml files
@@ -103,6 +120,7 @@ class OpenApiArt(object):
             module = importlib.import_module("openapiart.openapiartprotobuf")
             protobuf = getattr(module, "OpenApiArtProtobuf")(
                 **{
+                    "info": self._info,
                     "license": self._license,
                     "python_module_name": self._python_module_name,
                     "protobuf_file_name": self._protobuf_file_name,

--- a/openapiart/openapiartplugin.py
+++ b/openapiart/openapiartplugin.py
@@ -9,6 +9,7 @@ class OpenApiArtPlugin(object):
     def __init__(self, **kwargs):
         self._fp = None
         self._license = kwargs['license']
+        self._info = kwargs['info']
         self._output_dir = kwargs['output_dir']
         self._python_module_name = kwargs['python_module_name']
         self._protobuf_file_name = kwargs['protobuf_file_name']

--- a/openapiart/openapiartprotobuf.py
+++ b/openapiart/openapiartprotobuf.py
@@ -192,8 +192,9 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
         self._write("enum {} {{".format(enum_msg_name.replace(".", "")), indent=1)
         enums.insert(0, "UNSPECIFIED")
         id = 0
+        prefix = enum_msg_name.split("Enum")[0].upper()
         for enum in enums:
-            self._write("{} = {};".format(enum.upper(), id), indent=2)
+            self._write("{}_{} = {};".format(prefix, enum.upper(), id), indent=2)
             id += 1
         self._write("}", indent=1)
 
@@ -218,7 +219,8 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
             if "default" in property_object:
                 default = property_object["default"]
             if property_type.endswith("Enum") and default is not None:
-                default = "{}.{}".format(property_type.split(" ")[-1], default.upper())
+                prefix = property_type.split("Enum")[0].upper()
+                default = "{}.{}_{}".format(property_type.split(" ")[-1], prefix, default.upper())
             if "required" in schema_object and property_name in schema_object["required"] or property_type.startswith("repeated"):
                 optional = ""
             else:

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -76,6 +76,12 @@ components:
           type: number
           format: double
           default: 3.0
+        g_f:
+          description: |-
+            Another enum to test protbuf enum generation 
+          type: string
+          enum: [a, b, c]
+          default: a
 
     EObject:
       x-include:


### PR DESCRIPTION
Reference: https://developers.google.com/protocol-buffers/docs/style#enums

### Issue
Generated protobuf enums do not follow the google developers style guide.

### Fix
```
# this openapi def 
        choice:
          type: string
          enum: [g_d, g_e]
          default: 'g_d'

# translates to this protobuf definition
  enum ChoiceEnum {
    CHOICE_UNSPECIFIED = 0;
    CHOICE_G_D = 1;
    CHOICE_G_E = 2;
  }
  optional ChoiceEnum choice = 4 [
    (fld_meta).default = "ChoiceEnum.CHOICE_G_D",
    (fld_meta).description = "Description missing in models"
  ];
```

  
