### PR TITLE
Fix reponse message in generated protobuf file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 /build
 /dist
 /env
+/.vscode
+/scratch

--- a/openapiart/openapiartprotobuf.py
+++ b/openapiart/openapiartprotobuf.py
@@ -17,6 +17,8 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
         self._write_header(self._openapi["info"])
         for name, schema_object in self._openapi["components"]["schemas"].items():
             self._write_msg(name, schema_object)
+        for name, response_object in self._openapi["components"]["responses"].items():
+            self._write_msg(name, response_object)
         for _, path_object in self._openapi["paths"].items():
             self._write_request_msg(path_object)
             self._write_response_msg(path_object)
@@ -48,7 +50,7 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
                 for ref in self._get_parser('$..requestBody.."$ref"').find(path_item_object):
                     message = self._get_message_name(ref.value)
                     field_type = message.replace(".", "")
-                    field_name = field_type.lower()
+                    field_name = self._lowercase(field_type)
                     self._write("{} {} = 1;".format(field_type, field_name), indent=1)
                 self._write("}")
 
@@ -70,22 +72,26 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
                     detail_messages.append(detail_message)
                     self._write("message {} {{".format(detail_message), indent=1)
                     schema = self._get_parser("$..schema").find(response)
-                    if len(schema) != 0:
+                    if len(schema) == 0:
+                        if "$ref" in response:
+                            field_type = self._get_message_name(response["$ref"]).replace(".", "")
+                            self._write("{} {} = 1;".format(field_type, self._lowercase(field_type)), indent=2)
+                    else:
                         schema = schema[0].value
-                    if "$ref" in schema:
-                        field_type = self._get_message_name(schema["$ref"]).replace(".", "")
-                        self._write("{} {} = 1;".format(field_type, field_type.lower()), indent=2)
-                    elif "type" in schema:
-                        field_type = self._get_message_name(schema["type"]).replace(".", "")
-                        if "format" in schema and schema["format"] == "binary":
-                            field_type = "bytes"
-                        self._write("{} {} = 1;".format(field_type, field_type.lower()), indent=2)
+                        if "$ref" in schema:
+                            field_type = self._get_message_name(schema["$ref"]).replace(".", "")
+                            self._write("{} {} = 1;".format(field_type, self._lowercase(field_type)), indent=2)
+                        elif "type" in schema:
+                            field_type = self._get_message_name(schema["type"]).replace(".", "")
+                            if "format" in schema and schema["format"] == "binary":
+                                field_type = "bytes"
+                            self._write("{} {} = 1;".format(field_type, self._lowercase(field_type)), indent=2)
                     self._write("}", indent=1)
             self._write("oneof statuscode {", indent=1)
             id = 1
             for detail_message in detail_messages:
                 field_type = detail_message.replace(".", "")
-                field_name = field_type.lower().replace("-", "").replace("_", "")
+                field_name = self._lowercase(field_type)
                 self._write("{} {} = {};".format(field_type, field_name, id), indent=2)
                 id += 1
             self._write("}", indent=1)
@@ -182,22 +188,28 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
             camel_case += "{}{}".format(piece[0].upper(), piece[1:])
         return camel_case
 
-    def _uppercase(self, value):
-        upper_case = ""
+    def _camelcase_to_snakecase(self, value, lower=False):
+        word = ""
         insert_underscore = False
-        
+
         for c in value:
-            if c.isupper():
+            if c.isupper() or c.isdigit():
                 if insert_underscore:
-                    upper_case += "_" + c
+                    word += "_" + (c.lower() if lower else c)
                     insert_underscore = False
                 else:
-                    upper_case += c
+                    word += c.lower() if lower else c
             else:
-                upper_case += c.upper()
+                word += c if lower else c.upper()
                 insert_underscore = True
 
-        return upper_case
+        return word
+
+    def _uppercase(self, value):
+        return self._camelcase_to_snakecase(value, lower=False)
+
+    def _lowercase(self, value):
+        return self._camelcase_to_snakecase(value, lower=True)
 
     def _get_description(self, openapi_object):
         if "description" in openapi_object:
@@ -224,8 +236,21 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
         self._write()
         self._write("message {} {{".format(msg_name), indent=0)
         self._write('option (msg_meta).description = "{}";'.format(self._get_description(schema_object)), indent=1)
-        self._write_msg_fields(name, schema_object)
+        if "content" in schema_object:
+            # when accessing components/responses
+            self._write_response_fields(msg_name, schema_object)
+        else:
+            # when accessing components/schemas
+            self._write_msg_fields(name, schema_object)
         self._write("}")
+
+    def _write_response_fields(self, msg_name, schema_object):
+        try:
+            ref = schema_object["content"]["application/json"]["schema"]["$ref"]
+            field_type = self._get_message_name(ref).replace(".", "")
+            self._write("{} {} = 1;".format(field_type, self._lowercase(field_type)), indent=1)
+        except AttributeError as err:
+            print("Failed writing response {}: {}".format(msg_name, err))
 
     def _write_msg_fields(self, name, schema_object):
         if "properties" not in schema_object:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setuptools.setup(
         "jsonpath-ng",
         "typing",
     ],
-    tests_require=["pytest"],
+    extras_require={"testing": ["pytest", "flake8", "black"]},
     test_suite="tests",
 )


### PR DESCRIPTION
Fixes https://github.com/open-traffic-generator/openapiart/issues/36

- Generate messages for schemas in components/responses
- Convert field names to lower snake case for request/response messages
- Include black and flake8 as testing requirement

Please see attached old and new .proto for comparison.

[new.otg.proto.txt](https://github.com/open-traffic-generator/openapiart/files/6817509/new.otg.proto.txt)
[old.otg.proto.txt](https://github.com/open-traffic-generator/openapiart/files/6817511/old.otg.proto.txt)
