### PR TITLE
Fix choice code generation

### DIFF
--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -51,6 +51,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/JObject'
+        k:
+          description: A nested object with only one property which is a choice object
+          $ref: '#/components/schemas/KObject'
 
     GObject:
       x-include:
@@ -122,4 +125,12 @@ components:
         j_a:
           $ref: '#/components/schemas/EObject'
         j_b:
+          $ref: '#/components/schemas/FObject'
+
+    KObject:
+      type: object
+      properties:
+        e_object:
+          $ref: '#/components/schemas/EObject'
+        f_object:
           $ref: '#/components/schemas/FObject'

--- a/openapiart/tests/test_add.py
+++ b/openapiart/tests/test_add.py
@@ -13,6 +13,8 @@ def test_add(api):
     j.j_b.f_a = "a"
     print(config)
     assert config.g[0].choice == "g_d"
+    yaml = config.serialize(encoding=config.YAML)
+    config.deserialize(yaml)
 
 
 if __name__ == "__main__":

--- a/openapiart/tests/test_bundle.py
+++ b/openapiart/tests/test_bundle.py
@@ -12,12 +12,20 @@ def test_config(api):
     config.e.e_a = 1.1
     config.e.e_b = 1.2
     config.f.f_a = "a"
+    config.g.add(g_a="a g_a value")
     config.h = False
     config.i = "11011011"
+    j1, j2 = config.j.jobject().jobject()
+    assert j1 == j2
+    config.k.e_object.e_a = 77.7
+    config.k.f_object.f_a = "asdf"
+    # assert j1.choice == j1._DEFAULTS["choice"]
     djson = json.loads(config.serialize(config.JSON))
     assert jp.parse("$.a").find(djson)[0].value == config.a
     assert jp.parse("$.f.f_a").find(djson)[0].value == config.f.f_a
-    print(config)
+    yaml = config.serialize(encoding=config.JSON)
+    config.deserialize(yaml)
+    print(yaml)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes issue #50 

What: Only generate choice as an init parameter, an attribute, slot if choice is present in the model. Also deserialization should only deserialize those attributes found in ._TYPES.