### PR TITLE
Unit tests for the format keyword

### DIFF
--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -54,7 +54,9 @@ components:
         k:
           description: A nested object with only one property which is a choice object
           $ref: '#/components/schemas/KObject'
-
+        l:
+          $ref: '#/components/schemas/LObject'
+          
     GObject:
       x-include:
       - '../common/common.yaml#/components/schemas/ListObject'
@@ -134,3 +136,33 @@ components:
           $ref: '#/components/schemas/EObject'
         f_object:
           $ref: '#/components/schemas/FObject'
+
+    LObject:
+      description: |-
+        Format validation object
+      type: object
+      properties:
+        string:
+          type: string
+        integer:
+          type: integer
+          minimum: 10
+          maximum: 90
+        float:
+          type: number
+          format: float
+        double:
+          type: number
+          format: double
+        mac:
+          type: string
+          format: mac
+        ipv4:
+          type: string
+          format: ipv4
+        ipv6:
+          type: string
+          format: ipv6
+        hex:
+          type: string
+          format: hex

--- a/openapiart/tests/conftest.py
+++ b/openapiart/tests/conftest.py
@@ -5,35 +5,42 @@ import importlib
 import logging
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def openapiart():
     """Return an instance of the OpenApiArt class
 
-    Instantiating the OpenApiArt class generates OpenAPI artifacts and an 
+    Instantiating the OpenApiArt class generates OpenAPI artifacts and an
     enhanced ux python package.
     """
-    sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..')))
+    sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "..")))
     api_files = [
-        os.path.join(os.path.dirname(__file__), './api/info.yaml'),
-        os.path.join(os.path.dirname(__file__), './common/common.yaml'),
-        os.path.join(os.path.dirname(__file__), './api/api.yaml')
+        os.path.join(os.path.dirname(__file__), "./api/info.yaml"),
+        os.path.join(os.path.dirname(__file__), "./common/common.yaml"),
+        os.path.join(os.path.dirname(__file__), "./api/api.yaml"),
     ]
-    module = importlib.import_module('openapiart.openapiart')
-    openapiart_class = getattr(module, 'OpenApiArt')
-    openapiart = openapiart_class(api_files=api_files, 
-        output_dir='./.output/openapiart', 
-        python_module_name='sanity',
-        protobuf_file_name='sanity',
-        protobuf_package_name='test.sanity',
-        extension_prefix='sanity')
+    module = importlib.import_module("openapiart.openapiart")
+    openapiart_class = getattr(module, "OpenApiArt")
+    openapiart = openapiart_class(
+        api_files=api_files,
+        output_dir="./.output/openapiart",
+        python_module_name="sanity",
+        protobuf_file_name="sanity",
+        protobuf_package_name="test.sanity",
+        extension_prefix="sanity",
+    )
     return openapiart
 
 
 @pytest.fixture
 def api(openapiart):
-    """Return an instance of the top level Api class from the generated package
-    """
+    """Return an instance of the top level Api class from the generated package"""
     sys.path.append(openapiart.output_dir)
     module = importlib.import_module(openapiart.python_module_name)
     package = getattr(module, openapiart.python_module_name)
     return package.api(location=None, verify=False, logger=None, loglevel=logging.DEBUG)
+
+
+@pytest.fixture
+def config(api):
+    """Return a new instance of an empty config"""
+    return api.prefix_config()

--- a/openapiart/tests/test_formats.py
+++ b/openapiart/tests/test_formats.py
@@ -1,0 +1,110 @@
+import pytest
+import jsonpath_ng as jp
+import json
+
+
+def test_formats_sanity(config):
+    config.l.string = "asdf"
+    config.l.integer = 88
+    config.l.float = 22.3
+    config.l.double = 2342.222
+    config.l.mac = "00:00:fa:ce:fa:ce"
+    config.l.ipv4 = "1.1.1.1"
+    config.l.ipv6 = "::02"
+    config.l.hex = "0102030405060708090a0b0c0d0e0f"
+    yaml = config.serialize(encoding=config.YAML)
+    config.deserialize(yaml)
+    print(yaml)
+
+
+@pytest.mark.parametrize("value", [33.4, 100])
+def test_formats_bad_string(config, value):
+    config.l.string = value
+    try:
+        config.deserialize(config.serialize(encoding=config.YAML))
+        pytest.fail(f"Value {value} was successfully validated")
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("value", [33.4, "asdf"])
+def test_formats_bad_integer(config, value):
+    config.l.integer = value
+    try:
+        config.deserialize(config.serialize(encoding=config.YAML))
+        pytest.fail(f"Value {value} was successfully validated")
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("value", [6, 100, -20])
+def test_formats_integer_to_be_removed(config, value):
+    """These test cases are currently passing and should not
+    Once the base validation infrastructure is fixed these test cases should
+    be added to the test_formats_bad_integer
+    """
+    config.l.integer = value
+    config.deserialize(config.serialize(encoding=config.YAML))
+
+
+@pytest.mark.parametrize("value", ["1.1.1.1", "01.002.003.4"])
+def test_formats_good_ipv4(config, value):
+    config.l.ipv4 = value
+    try:
+        config.deserialize(config.serialize(encoding=config.YAML))
+    except TypeError:
+        pytest.fail(f"Value {value} was not valid")
+
+
+@pytest.mark.parametrize("value", [33.4, "asdf", 100, -20, "::01", "1.1.1.1.1"])
+def test_formats_bad_ipv4(config, value):
+    config.l.ipv4 = value
+    try:
+        config.deserialize(config.serialize(encoding=config.YAML))
+        pytest.fail(f"Value {value} was successfully validated")
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("value", ["1.1", "1.1.1"])
+def test_formats_ipv4_to_be_removed(config, value):
+    """These test cases are currently passing and should not
+    Once the base validation infrastructure is fixed these test cases should
+    be added to the test_formats_bad_ipv4
+    """
+    config.l.ipv4 = value
+    config.deserialize(config.serialize(encoding=config.YAML))
+
+
+@pytest.mark.parametrize("value", [33.4, "asdf", "1.1.1.1", 100, -20])
+def test_formats_bad_ipv6(config, value):
+    config.l.ipv6 = value
+    try:
+        config.deserialize(config.serialize(encoding=config.YAML))
+        pytest.fail(f"Value {value} was successfully validated")
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("value", [1, 2.2, "1.1.1.1", "::01", "00:00:00", "00:00:00:00:gg:00", "00:00:fa:ce:fa:ce:01"])
+def test_formats_bad_mac(config, value):
+    config.l.mac = value
+    try:
+        config.deserialize(config.serialize(encoding=config.YAML))
+        pytest.fail(f"Value {value} was successfully validated")
+    except TypeError:
+        pass
+
+
+@pytest.mark.parametrize("value", [1, 2.2, "1.1.1.1", "::01", "00:00:fa:ce:fa:ce:01"])
+def test_formats_bad_hex(config, value):
+    config.l.hex = value
+    try:
+        config.deserialize(config.serialize(encoding=config.YAML))
+        pytest.fail(f"Value {value} was successfully validated")
+    except TypeError:
+        pass
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", "-s", __file__])


### PR DESCRIPTION
Issue: There are no unit tests for the format keyword. OpenApiArt supports the following for the format keyword: float, double, mac, ipv4, ipv6. Unit tests for generated SDK's should verify that validation is correct for the supported format keyword.

Sample formats
```yaml
properties:
  float:
    type: number
    format: float
  double:
    type: number
    format: double
  mac:
    type: string
    format: mac
  ipv4:
    type: string
    format: ipv4
  ipv6:
    type: string
    format: ipv6
  hex:
    type: string
    format: hex
``` 