### PR TITLE
Go sdk path fix

### DIFF
--- a/openapiart/openapiart.py
+++ b/openapiart/openapiart.py
@@ -137,7 +137,7 @@ class OpenApiArt(object):
 
         # this generates the go stubs
         if self._go_sdk_package_dir and self._protobuf_package_name:
-            go_sdk_output_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", os.path.split(self._go_sdk_package_dir)[-1]))
+            go_sdk_output_dir = os.path.normpath(os.path.join(self._output_dir, "..", os.path.split(self._go_sdk_package_dir)[-1]))
             go_protobuffer_out_dir = os.path.normpath(os.path.join(go_sdk_output_dir, self._protobuf_package_name))
             os.makedirs(go_protobuffer_out_dir, exist_ok=True)
             process_args = [

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -121,7 +121,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
 
     def generate(self, openapi):
         self._openapi = openapi
-        self._ux_path = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", os.path.split(self._go_sdk_package_dir)[-1]))
+        self._ux_path = os.path.normpath(os.path.join(self._output_dir, "..", os.path.split(self._go_sdk_package_dir)[-1]))
         self._protoc_path = os.path.normpath(os.path.join(self._ux_path, self._protobuf_package_name))
         self._structs = {}
         self._write_mod_file()


### PR DESCRIPTION
When openapiart is installed via pip and as the package reside under site-packages. fetching dir name with __file__ causing to fetch the site-package path of openapiart and all the go sdk stuff is getting created under it.
#77 