### PR TITLE
Fstring fix

### DIFF
--- a/openapiart/openapiart.py
+++ b/openapiart/openapiart.py
@@ -43,7 +43,7 @@ class OpenApiArt(object):
         self._go_sdk_package_name = go_sdk_package_name
         self._extension_prefix = extension_prefix
         self._output_dir = os.path.abspath(output_dir)
-        print(f"Artifact output directory: {self._output_dir}")
+        print("Artifact output directory: {output_dir}".format(output_dir=self._output_dir))
         shutil.rmtree(self._output_dir, ignore_errors=True)
         self._api_files = api_files
         self._bundle()

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -164,12 +164,15 @@ class OpenApiArtGo(OpenApiArtPlugin):
         self._write()
 
     def _write_package(self):
-        self._write(f"package {self._go_sdk_package_name}")
+        self._write("package {go_sdk_package_name}".format(go_sdk_package_name=self._go_sdk_package_name))
         self._write()
 
     def _write_common_code(self):
         """Writes the base wrapper go code"""
-        self._write(f'''import {self._protobuf_package_name} "{self._go_sdk_package_dir}/{self._protobuf_package_name}"''')
+        line = "import {pb_pkg_name} \"{go_sdk_pkg_dir}/{pb_pkg_name}\"".format(
+            pb_pkg_name=self._protobuf_package_name, go_sdk_pkg_dir=self._go_sdk_package_dir
+        )
+        self._write(line)
         self._write('import "google.golang.org/grpc"')
         with open(os.path.join(os.path.dirname(__file__), "common.go")) as fp:
             self._write(fp.read().strip().strip("\n"))
@@ -178,7 +181,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
     def _write_types(self):
         for _, go_type in self._oapi_go_types.items():
             if go_type.startswith("String"):
-                self._write(f"type {go_type} string")
+                self._write("type {go_type} string".format(go_type=go_type))
         self._write()
 
     def _get_internal_name(self, openapi_name):
@@ -199,8 +202,12 @@ class OpenApiArtGo(OpenApiArtPlugin):
         return self._get_external_name(openapi_name) + "_"
 
     def _build_api_interface(self):
-        self._api.internal_struct_name = f"""{self._get_internal_name(self._go_sdk_package_name)}Api"""
-        self._api.external_interface_name = f"""{self._get_external_name(self._go_sdk_package_name)}Api"""
+        self._api.internal_struct_name = """{internal_name}Api""".format(
+            internal_name=self._get_internal_name(self._go_sdk_package_name)
+        )
+        self._api.external_interface_name = """{external_name}Api""".format(
+            external_name=self._get_external_name(self._go_sdk_package_name)
+        )
         for _, path_object in self._openapi["paths"].items():
             for _, path_item_object in path_object.items():
                 ref = self._get_parser("$..requestBody..'$ref'").find(path_item_object)
@@ -210,41 +217,46 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     new.schema_object = self._get_schema_object_from_ref(ref[0].value)
                     new.interface = self._get_external_name(new.schema_name)
                     new.struct = self._get_internal_name(new.schema_name)
-                    new.method = f"""New{new.interface}() {new.interface}"""
+                    new.method = """New{interface}() {interface}""".format(interface=new.interface)
                     if len([m for m in self._api.external_new_methods if m.schema_name == new.schema_name]) == 0:
                         self._api.external_new_methods.append(new)
                     rpc = FluentRpc()
                     rpc.operation_name = self._get_external_name(path_item_object["operationId"])
-                    rpc.method = f"""{rpc.operation_name}({new.struct} {new.interface}) error"""
-                    rpc.request = f"""{self._protobuf_package_name}.{rpc.operation_name}Request{{{new.interface}: {new.struct}.msg()}}"""
+                    rpc.method = """{operation_name}({struct} {interface}) error""".format(
+                        operation_name=rpc.operation_name, struct=new.struct, interface=new.interface
+                    )
+                    rpc.request = "{pb_pkg_name}.{operation_name}Request{{{interface}: {struct}.msg()}}".format(
+                        pb_pkg_name=self._protobuf_package_name, operation_name=rpc.operation_name,
+                        interface=new.interface, struct=new.struct
+                    )
                     if len([m for m in self._api.external_rpc_methods if m.operation_name == rpc.operation_name]) == 0:
                         self._api.external_rpc_methods.append(rpc)
 
         # write the go code
         self._write(
-            f"""type {self._api.internal_struct_name} struct {{
+            """type {internal_struct_name} struct {{
                 api
-                grpcClient {self._protobuf_package_name}.OpenapiClient
+                grpcClient {pb_pkg_name}.OpenapiClient
             }}
 
             // grpcConnect builds up a grpc connection
-            func (api *{self._api.internal_struct_name}) grpcConnect() error {{
+            func (api *{internal_struct_name}) grpcConnect() error {{
                 if api.grpcClient == nil {{
                     conn, err := grpc.Dial(api.grpc.location, grpc.WithInsecure())
                     if err != nil {{
                         return err
                     }}
-                    api.grpcClient = {self._protobuf_package_name}.NewOpenapiClient(conn)
+                    api.grpcClient = {pb_pkg_name}.NewOpenapiClient(conn)
                 }}
                 return nil
             }}
 
             // NewApi returns a new instance of the top level interface hierarchy
-            func NewApi() *{self._api.internal_struct_name} {{
-                api := {self._api.internal_struct_name}{{}}
+            func NewApi() *{internal_struct_name} {{
+                api := {internal_struct_name}{{}}
                 return &api
             }}
-            """
+            """.format(internal_struct_name=self._api.internal_struct_name, pb_pkg_name=self._protobuf_package_name,)
         )
         methods = []
         for new in self._api.external_new_methods:
@@ -253,29 +265,35 @@ class OpenApiArtGo(OpenApiArtPlugin):
             methods.append(rpc.method)
         method_signatures = "\n".join(methods)
         self._write(
-            f"""type {self._api.external_interface_name} interface {{
+            """type {external_interface_name} interface {{
                 Api
                 {method_signatures}
             }}
-            """
+            """.format(
+                external_interface_name=self._api.external_interface_name,
+                method_signatures=method_signatures
+            )
         )
         for new in self._api.external_new_methods:
             self._write(
-                f"""func (api *{self._api.internal_struct_name}) {new.method} {{
-                    return &{new.struct}{{obj: &{self._protobuf_package_name}.{new.interface}{{}}}}
+                """func (api *{internal_struct_name}) {method} {{
+                    return &{struct}{{obj: &{pb_pkg_name}.{interface}{{}}}}
                 }}
-                """
+                """.format(
+                    internal_struct_name=self._api.internal_struct_name, method=new.method, struct=new.struct,
+                    pb_pkg_name=self._protobuf_package_name, interface=new.interface
+                )
             )
         for rpc in self._api.external_rpc_methods:
             self._write(
-                f"""func (api *{self._api.internal_struct_name}) {rpc.method} {{
+                """func (api *{internal_struct_name}) {method} {{
                     if err := api.grpcConnect(); err != nil {{
                         return err
                     }}
-                    request := {rpc.request}
+                    request := {request}
                     ctx, cancelFunc := context.WithTimeout(context.Background(), api.grpc.requestTimeout)
                     defer cancelFunc()
-                    client, err := api.grpcClient.{rpc.operation_name}(ctx, &request)
+                    client, err := api.grpcClient.{operation_name}(ctx, &request)
                     if err != nil {{
                         return err
                     }}
@@ -285,7 +303,10 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     }}
                     return nil
                 }}
-                """
+                """.format(
+                    internal_struct_name=self._api.internal_struct_name, method=rpc.method,
+                    request=rpc.request, operation_name=rpc.operation_name
+                )
             )
 
     def _build_request_interfaces(self):
@@ -302,24 +323,26 @@ class OpenApiArtGo(OpenApiArtPlugin):
 
     def _build_interface(self, new):
         self._write(
-            f"""type {new.struct} struct {{
-                obj *{self._protobuf_package_name}.{new.interface}
+            """type {struct} struct {{
+                obj *{pb_pkg_name}.{interface}
             }}
             
-            func (obj *{new.struct}) msg() *{self._protobuf_package_name}.{new.interface} {{
+            func (obj *{struct}) msg() *{pb_pkg_name}.{interface} {{
                 return obj.obj
             }}
 
-            func (obj *{new.struct}) Yaml() string {{
+            func (obj *{struct}) Yaml() string {{
                 data, _ := yaml.Marshal(obj.msg())
                 return string(data)
             }}
 
-            func (obj *{new.struct}) Json() string {{
+            func (obj *{struct}) Json() string {{
                 data, _ := json.Marshal(obj.msg())
                 return string(data)
             }}
-        """
+        """.format(
+            struct=new.struct, pb_pkg_name=self._protobuf_package_name, interface=new.interface
+        )
         )
         self._build_setters_getters(new)
         interfaces = ["Yaml() string", "Json() string"]
@@ -331,11 +354,14 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 interfaces.append(field.adder_method)
         interface_signatures = "\n".join(interfaces)
         self._write(
-            f"""type {new.interface} interface {{
-                msg() *{self._protobuf_package_name}.{new.interface}
+            """type {interface} interface {{
+                msg() *{pb_pkg_name}.{interface}
                 {interface_signatures}
             }}
-        """
+        """.format(
+            interface=new.interface, pb_pkg_name=self._protobuf_package_name,
+            interface_signatures=interface_signatures
+        )
         )
         for field in new.interface_fields:
             self._write_field_getter(new, field)
@@ -348,82 +374,97 @@ class OpenApiArtGo(OpenApiArtPlugin):
             return
         elif field.isArray:
             if field.struct:
-                body = f"""if obj.obj.{field.name} == nil {{
-                        obj.obj.{field.name} = make([]*{self._protobuf_package_name}.{field.external_struct}, 0)
+                body = """if obj.obj.{name} == nil {{
+                        obj.obj.{name} = make([]*{pb_pkg_name}.{external_struct}, 0)
                     }}
-                    values := make([]{field.external_struct}, 0)
-                    for _, item := range obj.obj.{field.name} {{
-                        values = append(values, &{field.struct}{{obj: item}})
+                    values := make([]{external_struct}, 0)
+                    for _, item := range obj.obj.{name} {{
+                        values = append(values, &{struct}{{obj: item}})
                     }}
                     return values
-                """
+                """.format(
+                    name=field.name, pb_pkg_name=self._protobuf_package_name, external_struct=field.external_struct,
+                    struct=field.struct
+                )
             else:
-                body = f"""if obj.obj.{field.name} == nil {{
-                        obj.obj.{field.name} = make({field.type}, 0)
+                body = """if obj.obj.{name} == nil {{
+                        obj.obj.{name} = make({type}, 0)
                     }}
                     for _, item := range value {{
-                        obj.obj.{field.name} = append(obj.obj.{field.name}, item)
+                        obj.obj.{name} = append(obj.obj.{name}, item)
                     }}
                     return obj
-                """
+                """.format(name=field.name, type=field.type)
         elif field.struct is not None:
             if field.isPointer:
-                body = f"""if obj.obj.{field.name} == nil {{
-                        obj.obj.{field.name} = &{self._protobuf_package_name}.{field.external_struct}{{}}
+                body = """if obj.obj.{name} == nil {{
+                        obj.obj.{name} = &{pb_pkg_name}.{external_struct}{{}}
                     }}
-                    return &{field.struct}{{obj: obj.obj.{field.name}}}
-                """
+                    return &{struct}{{obj: obj.obj.{name}}}
+                """.format(
+                    name=field.name, pb_pkg_name=self._protobuf_package_name, external_struct=field.external_struct,
+                    struct=field.struct
+                )
             else:
-                body = f"return &{field.struct}{{obj: obj.obj.{field.name}}}"
+                body = "return &{struct}{{obj: obj.obj.{name}}}".format(
+                    struct=field.struct, name=field.name
+                )
         elif field.isPointer:
-            body = f"""return *obj.obj.{field.name}"""
+            body = """return *obj.obj.{name}""".format(name=field.name)
         else:
-            body = f"""return obj.obj.{field.name}"""
+            body = """return obj.obj.{name}""".format(name=field.name)
         self._write(
-            f"""func (obj *{new.struct}) {field.getter_method} {{
+            """func (obj *{struct}) {getter_method} {{
                 {body}
             }}
-            """
+            """.format(struct=new.struct, getter_method=field.getter_method, body=body)
         )
 
     def _write_field_setter(self, new, field):
         if field.setter_method is None:
             return
         if field.isArray:
-            body = f"""func (obj *{new.struct}) {field.setter_method} {{
-                if obj.obj.{field.name} == nil {{
-                    obj.obj.{field.name} = make({field.type}, 0)
+            body = """func (obj *{newstruct}) {fieldsetter_method} {{
+                if obj.obj.{fieldname} == nil {{
+                    obj.obj.{fieldname} = make({fieldtype}, 0)
                 }}
                 for _, item := range value {{
                     obj.obj.{field.name} = append(obj.obj.{field.name}, item)
                 }}
             }}
-            """
+            """.format(
+                newstruct=new.struct, fieldsetter_method=field.setter_method,
+                fieldname=field.name, fieldtype=field.type
+            )
         elif field.isPointer:
-            body = f"""obj.obj.{field.name} = &value"""
+            body = """obj.obj.{fieldname} = &value""".format(fieldname=field.name)
         else:
-            body = f"""obj.obj.{field.name} = value"""
+            body = """obj.obj.{fieldname} = value""".format(fieldname=field.name)
         self._write(
-            f"""func (obj *{new.struct}) {field.setter_method} {{
+            """func (obj *{newstruct}) {fieldsetter_method} {{
                 {body}
                 return obj
             }}
-            """
+            """.format(newstruct=new.struct, fieldsetter_method=field.setter_method, body=body)
         )
 
     def _write_field_adder(self, new, field):
         if field.adder_method is None:
             return
         self._write(
-            f"""func (obj *{new.struct}) {field.adder_method} {{
-                if obj.obj.{field.name} == nil {{
-                    obj.obj.{field.name} = make([]*{self._protobuf_package_name}.{field.external_struct}, 0)
+            """func (obj *{newstruct}) {fieldadder_method} {{
+                if obj.obj.{fieldname} == nil {{
+                    obj.obj.{fieldname} = make([]*{pb_pkg_name}.{fieldexternal_struct}, 0)
                 }}
-                slice := append(obj.obj.{field.name}, &{self._protobuf_package_name}.{field.external_struct}{{}})
-                obj.obj.{field.name} = slice
-                return &{field.struct}{{obj: slice[len(slice)-1]}}
+                slice := append(obj.obj.{fieldname}, &{pb_pkg_name}.{fieldexternal_struct}{{}})
+                obj.obj.{fieldname} = slice
+                return &{fieldstruct}{{obj: slice[len(slice)-1]}}
             }}
-            """
+            """.format(
+                newstruct=new.struct, fieldadder_method=field.adder_method, fieldname=field.name,
+                fieldtype=field.type, pb_pkg_name=self._protobuf_package_name, fieldexternal_struct=field.external_struct,
+                fieldstruct=field.struct
+            )
         )
 
     def _build_setters_getters(self, fluent_new):
@@ -442,7 +483,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 field.isPointer = False
             else:
                 field.isPointer = fluent_new.isOptional(property_name)
-            field.getter_method = f"{field.name}() {field.type}"
+            field.getter_method = "{name}() {ftype}".format(name=field.name, ftype=field.type)
             # if field.type not in self._oapi_go_types.values() and "$ref" not in property_schema:
             #     continue
             if "$ref" in property_schema:
@@ -450,16 +491,22 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 field.struct = self._get_internal_name(schema_name)
                 field.external_struct = self._get_external_name(schema_name)
             if field.type in self._oapi_go_types.values():
-                field.setter_method = f"Set{field.name}(value {field.type}) {fluent_new.interface}"
+                field.setter_method = "Set{name}(value {ftype}) {interface}".format(
+                    name=field.name, ftype=field.type, interface=fluent_new.interface
+                )
             elif "type" in property_schema and property_schema["type"] == "array":
                 if "$ref" in property_schema["items"]:
                     schema_name = self._get_schema_object_name_from_ref(property_schema["items"]["$ref"])
                     field.isArray = True
                     field.struct = self._get_internal_name(schema_name)
                     field.external_struct = self._get_external_name(schema_name)
-                    field.adder_method = f"New{field.name}() {field.external_struct}"
+                    field.adder_method = "New{name}() {external_struct}".format(
+                        name=field.name, external_struct=field.external_struct
+                    )
                 else:
-                    field.setter_method = f"Set{field.name}(value {field.type}) {fluent_new.interface}"
+                    field.setter_method = "Set{name}(value {ftype}) {interface}".format(
+                        name=field.name, ftype=field.type, interface=fluent_new.interface
+                    )
             fluent_new.interface_fields.append(field)
 
     def _get_schema_object_name_from_ref(self, ref):
@@ -478,13 +525,13 @@ class OpenApiArtGo(OpenApiArtPlugin):
         if "type" in property_schema:
             oapi_type = property_schema["type"]
             if oapi_type.lower() in self._oapi_go_types:
-                go_type = f"{self._oapi_go_types[oapi_type.lower()]}"
+                go_type = "{oapi_go_types}".format(oapi_go_types=self._oapi_go_types[oapi_type.lower()])
             if oapi_type == "array":
-                go_type += f"[]" + self._get_struct_field_type(property_schema["items"]).replace("*", "")
+                go_type += "[]" + self._get_struct_field_type(property_schema["items"]).replace("*", "")
             if "format" in property_schema:
                 format_type = (oapi_type + property_schema["format"]).lower()
                 if format_type.lower() in self._oapi_go_types:
-                    go_type = f"{self._oapi_go_types[format_type.lower()]}"
+                    go_type = "{oapi_go_type}".format(oapi_go_type=self._oapi_go_types[format_type.lower()])
         elif "$ref" in property_schema:
             ref = property_schema["$ref"]
             schema_object_name = self._get_schema_object_name_from_ref(ref)
@@ -501,11 +548,13 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 self._api.components[new.schema_name] = new
             go_type = new.interface
         else:
-            raise Exception(f"No type or $ref keyword present in property schema: {property_schema}")
+            raise Exception("No type or $ref keyword present in property schema: {property_schema}".format(
+                property_schema=property_schema
+            ))
         return go_type
 
     def _get_description(self, function_name, openapi_object):
-        description = f"// {function_name} TBD"
+        description = "// {function_name} TBD".format(function_name=function_name)
         if "description" in openapi_object:
             description = function_name + "\n" + openapi_object["description"].strip("\n")
             description = "/* {}\n*/".format(description)


### PR DESCRIPTION
All the f"{foo}" related strings are made compatible to python 2.7
"{foo}".format(foo=foo)

#82 