### PR TITLE
Move go and protoc installation steps to do.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Setup Go and protoc
+        run: |
+          sudo python do.py setup_ext
       - name: Install dependencies
         run: |
-          sudo python do.py setup
+          python do.py setup
           python do.py init
       - name: Build distribution
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Setup Go and protoc
         run: |
-          sudo python do.py setup_ext
+          python do.py setup_ext
       - name: Install dependencies
         run: |
           python do.py setup

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python do.py setup
+          sudo python do.py setup
           python do.py init
       - name: Build distribution
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install go
-        uses: actions/setup-go@v2
-        with:
-          stable: 'false'
-          go-version: 1.16.6
-      - name: Install protoc
-        uses: abelfodil/protoc-action@v1
-      - name: Get go dependencies
-        run: |
-          go get google.golang.org/protobuf/cmd/protoc-gen-go
-          go get google.golang.org/grpc/cmd/protoc-gen-go-grpc
-          go get golang.org/x/tools/cmd/goimports
       - name: Install dependencies
         run: |
           python do.py setup

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ __pycache__
 /scratch
 /cov_report
 /**/art
-
+.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:20.04
+ENV SRC_ROOT=/home/otg/openapiart
+RUN mkdir -p ${SRC_ROOT}
+# Get project source, install dependencies and build it
+COPY . ${SRC_ROOT}/
+RUN apt-get update \
+	&& apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    && apt-get -y install curl git vim unzip python-is-python3 python3-pip
+WORKDIR ${SRC_ROOT}
+CMD ["/bin/bash"]

--- a/do.py
+++ b/do.py
@@ -7,8 +7,8 @@ import subprocess
 import platform
 
 
-os.environ["GOPATH"] = "/home/go"
-os.environ["PATH"] = os.environ["PATH"] + ":/usr/local/go/bin:" + "/home/go/bin"
+os.environ["GOPATH"] = "/home/.local"
+os.environ["PATH"] = os.environ["PATH"] + ":{0}/go/bin:{0}/bin".format(os.environ["GOPATH"])
 
 
 def on_arm():
@@ -37,9 +37,12 @@ def get_go():
         print("host architecture not supported")
         return
 
+    if not os.path.exists(os.environ["GOPATH"]):
+        os.mkdir(os.environ["GOPATH"])
+
     print("Installing Go ...")
     cmd = "go version 2> /dev/null || curl -kL https://dl.google.com/go/" + targz
-    cmd += " | tar -C /usr/local/ -xzf -"
+    cmd += " | tar -C /home/.local -xzf -"
     run([cmd])
 
 
@@ -68,11 +71,11 @@ def get_protoc():
         return
 
     print("Installing protoc ...")
-    cmd = "protoc --version 2> /dev/null || ( curl -kL -o ./protc.zip "
+    cmd = "protoc --version 2> /dev/null || ( curl -kL -o ./protoc.zip "
     cmd += "https://github.com/protocolbuffers/protobuf/releases/download/v"
     cmd += version + "/" + zipfile
-    cmd += ' && unzip -o ./protc.zip -d /usr/local bin/protoc "include/*"'
-    cmd += ' && rm -rf ./protc.zip )'
+    cmd += ' && unzip ./protoc.zip -d /home/.local'
+    cmd += ' && rm -rf ./protoc.zip )'
     run([cmd])
 
 

--- a/do.py
+++ b/do.py
@@ -76,7 +76,7 @@ def get_protoc():
     run([cmd])
 
 
-def setup():
+def setup_ext():
     if on_linux():
         get_go()
         get_protoc()
@@ -84,6 +84,8 @@ def setup():
     else:
         print("Skipping go and protoc installation on non-linux platform ...")
 
+
+def setup():
     run(
         [
             py() + " -m pip install --upgrade pip",

--- a/do.py
+++ b/do.py
@@ -42,7 +42,7 @@ def get_go():
 
     print("Installing Go ...")
     cmd = "go version 2> /dev/null || curl -kL https://dl.google.com/go/" + targz
-    cmd += " | tar -C /home/.local -xzf -"
+    cmd += " | tar -C " + os.environ["GOPATH"] + " -xzf -"
     run([cmd])
 
 

--- a/do.py
+++ b/do.py
@@ -4,9 +4,86 @@ import re
 import sys
 import shutil
 import subprocess
+import platform
+
+
+os.environ["GOPATH"] = "/home/go"
+os.environ["PATH"] = os.environ["PATH"] + ":/usr/local/go/bin:" + "/home/go/bin"
+
+
+def on_arm():
+    arch = platform.uname().machine.lower()
+    return arch == "arm64" or arch == "aarch64"
+
+
+def on_x86():
+    arch = platform.uname().machine.lower()
+    return arch == "x86_64"
+
+
+def on_linux():
+    return sys.platform == "linux"
+
+
+def get_go():
+    version = "1.17"
+    targz = None
+
+    if on_arm():
+        targz = "go" + version + ".linux-arm64.tar.gz"
+    elif on_x86():
+        targz = "go" + version + ".linux-amd64.tar.gz"
+    else:
+        print("host architecture not supported")
+        return
+
+    print("Installing Go ...")
+    cmd = "go version 2> /dev/null || curl -kL https://dl.google.com/go/" + targz
+    cmd += " | tar -C /usr/local/ -xzf -"
+    run([cmd])
+
+
+def get_go_deps():
+    print("Getting Go libraries for grpc / protobuf ...")
+    cmd = "GO111MODULE=on go get -v"
+    run(
+        [
+            cmd + " google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1.0",
+            cmd + " google.golang.org/protobuf/cmd/protoc-gen-go@v1.25.0",
+            cmd + " golang.org/x/tools/cmd/goimports"
+        ]
+    )
+
+
+def get_protoc():
+    version = "3.17.3"
+    zipfile = None
+
+    if on_arm():
+        zipfile = "protoc-" + version + "-linux-aarch_64.zip"
+    elif on_x86():
+        zipfile = "protoc-" + version + "-linux-x86_64.zip"
+    else:
+        print("host architecture not supported")
+        return
+
+    print("Installing protoc ...")
+    cmd = "protoc --version 2> /dev/null || ( curl -kL -o ./protc.zip "
+    cmd += "https://github.com/protocolbuffers/protobuf/releases/download/v"
+    cmd += version + "/" + zipfile
+    cmd += ' && unzip -o ./protc.zip -d /usr/local bin/protoc "include/*"'
+    cmd += ' && rm -rf ./protc.zip )'
+    run([cmd])
 
 
 def setup():
+    if on_linux():
+        get_go()
+        get_protoc()
+        get_go_deps()
+    else:
+        print("Skipping go and protoc installation on non-linux platform ...")
+
     run(
         [
             py() + " -m pip install --upgrade pip",
@@ -189,32 +266,6 @@ def py():
         # since some paths may contain spaces
         py.path = '"' + py.path + '"'
         return py.path
-
-
-def get_protoc():
-    PROTOC_VERSION = "3.17.3"
-    PROTOC_ZIP = "protoc-%s-linux-aarch_64.zip" % PROTOC_VERSION
-    process_args = [
-        "curl",
-        "-kL",
-        "-o",
-        "./protc.zip",
-        "https://github.com/protocolbuffers/protobuf/releases/download/v%s/%s" % (PROTOC_VERSION, PROTOC_ZIP),
-        "&&",
-        "unzip",
-        "-o",
-        "./protc.zip",
-        "-d",
-        "{$HOME}" "bin/protoc",
-        "include/*",
-        "&&",
-        "rm",
-        "-rf",
-        "./protc.zip",
-    ]
-    process = subprocess.Popen(process_args, shell=True)
-    process.wait()
-    return
 
 
 def run(commands):

--- a/do.py
+++ b/do.py
@@ -74,7 +74,7 @@ def get_protoc():
     cmd = "protoc --version 2> /dev/null || ( curl -kL -o ./protoc.zip "
     cmd += "https://github.com/protocolbuffers/protobuf/releases/download/v"
     cmd += version + "/" + zipfile
-    cmd += ' && unzip ./protoc.zip -d /home/.local'
+    cmd += ' && unzip ./protoc.zip -d .local'
     cmd += ' && rm -rf ./protoc.zip )'
     run([cmd])
 

--- a/do.py
+++ b/do.py
@@ -7,7 +7,9 @@ import subprocess
 import platform
 
 
-os.environ["GOPATH"] = ".local"
+os.environ["GOPATH"] = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), ".local"
+)
 os.environ["PATH"] = os.environ["PATH"] + ":{0}/go/bin:{0}/bin".format(os.environ["GOPATH"])
 
 
@@ -74,7 +76,7 @@ def get_protoc():
     cmd = "protoc --version 2> /dev/null || ( curl -kL -o ./protoc.zip "
     cmd += "https://github.com/protocolbuffers/protobuf/releases/download/v"
     cmd += version + "/" + zipfile
-    cmd += ' && unzip ./protoc.zip -d .local'
+    cmd += ' && unzip ./protoc.zip -d ' + os.environ["GOPATH"]
     cmd += ' && rm -rf ./protoc.zip )'
     run([cmd])
 

--- a/do.py
+++ b/do.py
@@ -7,7 +7,7 @@ import subprocess
 import platform
 
 
-os.environ["GOPATH"] = "/home/.local"
+os.environ["GOPATH"] = ".local"
 os.environ["PATH"] = os.environ["PATH"] + ":{0}/go/bin:{0}/bin".format(os.environ["GOPATH"])
 
 

--- a/openapiart/openapiart.py
+++ b/openapiart/openapiart.py
@@ -148,8 +148,9 @@ class OpenApiArt(object):
                 "--experimental_allow_proto3_optional",
                 "{}.proto".format(self._protobuf_package_name),
             ]
-            print("Generating go stubs: {}".format(" ".join(process_args)))
-            subprocess.check_call(process_args, shell=False)
+            cmd = " ".join(process_args)
+            print("Generating go gRPC stubs: {}".format(cmd))
+            subprocess.check_call(cmd, shell=True)
 
         # this generates the go ux module
         if self._protobuf_package_name and self._go_sdk_package_dir:

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -601,8 +601,9 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 "-w",
                 self._filename,
             ]
-            print("Formatting generated go ux file: {}".format(" ".join(process_args)))
-            process = subprocess.Popen(process_args, cwd=self._ux_path, shell=False)
+            cmd = " ".join(process_args)
+            print("Formatting generated go ux file: {}".format(cmd))
+            process = subprocess.Popen(cmd, cwd=self._ux_path, shell=True)
             process.wait()
         except Exception as e:
             print("Bypassed formatting of generated go ux file: {}".format(e))


### PR DESCRIPTION
- go and protoc are now installed inside `.local` dir in pwd using `python do.py setup_ext`
- if go and protoc is already installed, PATH and GOPATH inside do.py needs to be modified accordingly
- subprocess invokation is using `shell=True` for some places to allow passing parent's env to child
- Dockerfile has been added to setup ubuntu20.4 env if needed (for dev)
  ```sh
  cd openapiart && docker build . -t openapiart:dev
  docker start -td openapiart:dev
  
  # attach to container manually or using vscode
  docker exec -it <container id> /bin/bash
  ```