### PR TITLE
Wrap struct arrays in a generated List object

### DIFF
--- a/pkg/openapiart.go
+++ b/pkg/openapiart.go
@@ -206,14 +206,12 @@ type PrefixConfig interface {
 	SetC(value int32) PrefixConfig
 	E() EObject
 	F() FObject
-	G() []GObject
-	NewG() GObject
+	G() GObjectList
 	H() bool
 	SetH(value bool) PrefixConfig
 	I() []byte
 	SetI(value []byte) PrefixConfig
-	J() []JObject
-	NewJ() JObject
+	J() JObjectList
 	K() KObject
 	L() LObject
 	Level() LevelOne
@@ -292,27 +290,35 @@ func (obj *prefixConfig) F() FObject {
 
 // G returns a []GObject
 //  A list of objects with choice and properties
-func (obj *prefixConfig) G() []GObject {
+func (obj *prefixConfig) G() GObjectList {
 	if obj.obj.G == nil {
-		obj.obj.G = make([]*sanity.GObject, 0)
+		obj.obj.G = []*sanity.GObject{}
 	}
-	values := make([]GObject, 0)
-	for _, item := range obj.obj.G {
-		values = append(values, &gObject{obj: item})
-	}
-	return values
+	return &gObjectList{obj: obj}
 
 }
 
-// NewG creates and returns a new GObject object
-//  A list of objects with choice and properties
-func (obj *prefixConfig) NewG() GObject {
-	if obj.obj.G == nil {
-		obj.obj.G = make([]*sanity.GObject, 0)
+type gObjectList struct {
+	obj *prefixConfig
+}
+
+type GObjectList interface {
+	Add() GObject
+	Items() []GObject
+}
+
+func (obj *gObjectList) Add() GObject {
+	newObj := &sanity.GObject{}
+	obj.obj.obj.G = append(obj.obj.obj.G, newObj)
+	return &gObject{obj: newObj}
+}
+
+func (obj *gObjectList) Items() []GObject {
+	slice := []GObject{}
+	for _, item := range obj.obj.obj.G {
+		slice = append(slice, &gObject{obj: item})
 	}
-	slice := append(obj.obj.G, &sanity.GObject{})
-	obj.obj.G = slice
-	return &gObject{obj: slice[len(slice)-1]}
+	return slice
 }
 
 // H returns a bool
@@ -343,27 +349,35 @@ func (obj *prefixConfig) SetI(value []byte) PrefixConfig {
 
 // J returns a []JObject
 //  A list of objects with only choice
-func (obj *prefixConfig) J() []JObject {
+func (obj *prefixConfig) J() JObjectList {
 	if obj.obj.J == nil {
-		obj.obj.J = make([]*sanity.JObject, 0)
+		obj.obj.J = []*sanity.JObject{}
 	}
-	values := make([]JObject, 0)
-	for _, item := range obj.obj.J {
-		values = append(values, &jObject{obj: item})
-	}
-	return values
+	return &jObjectList{obj: obj}
 
 }
 
-// NewJ creates and returns a new JObject object
-//  A list of objects with only choice
-func (obj *prefixConfig) NewJ() JObject {
-	if obj.obj.J == nil {
-		obj.obj.J = make([]*sanity.JObject, 0)
+type jObjectList struct {
+	obj *prefixConfig
+}
+
+type JObjectList interface {
+	Add() JObject
+	Items() []JObject
+}
+
+func (obj *jObjectList) Add() JObject {
+	newObj := &sanity.JObject{}
+	obj.obj.obj.J = append(obj.obj.obj.J, newObj)
+	return &jObject{obj: newObj}
+}
+
+func (obj *jObjectList) Items() []JObject {
+	slice := []JObject{}
+	for _, item := range obj.obj.obj.J {
+		slice = append(slice, &jObject{obj: item})
 	}
-	slice := append(obj.obj.J, &sanity.JObject{})
-	obj.obj.J = slice
-	return &jObject{obj: slice[len(slice)-1]}
+	return slice
 }
 
 // K returns a KObject

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -82,8 +82,18 @@ func TestGetObject(t *testing.T) {
 
 func TestAddObject(t *testing.T) {
 	config := NewApi().NewPrefixConfig()
-	g := config.NewG()
-	g.SetName("G-1")
+	config.G().Add().SetName("G1").SetGA("ga string").SetGB(232)
+	config.G().Add().SetName("G2")
+	config.G().Add().SetName("G3").SetGA("3 is not 2 or 1 or none")
+	config.J().Add().JB().SetFA("a FA string")
+	config.J().Add().JA().SetEA(22.2)
+	for _, item := range config.G().Items() {
+		fmt.Println(item.Name())
+	}
+	name := "new persistent name"
+	config.G().Items()[1].SetName(name)
+	assert.Equal(t, len(config.G().Items()), 3)
+	assert.Equal(t, config.G().Items()[1].Name(), name)
 	fmt.Println(config.Yaml())
 }
 


### PR DESCRIPTION
Why: Generating New<structname> had inconsistent/awkward naming as the struct name is taken from the field name (ie NewPorts).  The New<structname> was also being done on the parent object of the field whereas it should be done on the field array.  Using the generated structname is too brittle as it subject to model name changes as opposed to property names which must remain backward compatible.

The solution is to generate a list wrapper struct and interface.
This approach is:
- consistent regarding method naming (Add)
- consistent regarding access (on the field as opposed to the containing struct)
-  not as brittle as using the #/components/schemas/<object name>.
- an extensible ux design
```go
config := NewApi().NewConfig()
p1 := config.Ports().Add().SetName("P1").SetLocation("1.1.1.1/1/1")
p2 := config.Ports().Add().SetName("P1").SetLocation("1.1.1.1/1/2")
for _, item := range config.Ports().Items() {
    fmt.Println(item.Name(), item.Location())
}
```