### PR TITLE
Generate yaml serdes

### DIFF
--- a/openapiart/common.go
+++ b/openapiart/common.go
@@ -2,8 +2,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	"gopkg.in/yaml.v3"
 )
 
 type grpcTransport struct {

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -188,6 +188,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
         self._write(line)
         self._write('import "google.golang.org/protobuf/types/known/emptypb"')
         self._write('import "google.golang.org/grpc"')
+        self._write('import "github.com/ghodss/yaml"')
         with open(os.path.join(os.path.dirname(__file__), "common.go")) as fp:
             self._write(fp.read().strip().strip("\n"))
         self._write()
@@ -405,12 +406,14 @@ class OpenApiArtGo(OpenApiArtPlugin):
             }}
 
             func (obj *{struct}) ToYaml() string {{
-                data, _ := yaml.Marshal(obj.msg())
+                data, _ := json.Marshal(obj.msg())
+                data, _ = yaml.JSONToYAML(data)
                 return string(data)
             }}
 
             func (obj *{struct}) FromYaml(value string) error {{
-                return yaml.Unmarshal([]byte(value), obj.msg())
+                data, _ := yaml.YAMLToJSON([]byte(value))
+                return json.Unmarshal([]byte(data), obj.msg())
             }}
 
             func (obj *{struct}) ToJson() string {{

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -3,9 +3,9 @@ module github.com/open-traffic-generator/openapiart/pkg
 go 1.16
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.40.0
 	google.golang.org/protobuf v1.27.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 )

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -17,6 +17,7 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -118,9 +119,9 @@ google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQ
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.3 h1:fvjTMHxHEw/mxHbtzPi3JCcKXQRAnQTBRo6YCJSVHKI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
-gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/openapiart.go
+++ b/pkg/openapiart.go
@@ -9,10 +9,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ghodss/yaml"
 	sanity "github.com/open-traffic-generator/openapiart/pkg/sanity"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"gopkg.in/yaml.v3"
 )
 
 type grpcTransport struct {
@@ -242,12 +242,14 @@ func (obj *prefixConfig) msg() *sanity.PrefixConfig {
 }
 
 func (obj *prefixConfig) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *prefixConfig) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *prefixConfig) ToJson() string {
@@ -602,12 +604,14 @@ func (obj *updateConfig) msg() *sanity.UpdateConfig {
 }
 
 func (obj *updateConfig) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *updateConfig) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *updateConfig) ToJson() string {
@@ -668,12 +672,14 @@ func (obj *eObject) msg() *sanity.EObject {
 }
 
 func (obj *eObject) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *eObject) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *eObject) ToJson() string {
@@ -775,12 +781,14 @@ func (obj *fObject) msg() *sanity.FObject {
 }
 
 func (obj *fObject) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *fObject) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *fObject) ToJson() string {
@@ -837,12 +845,14 @@ func (obj *gObject) msg() *sanity.GObject {
 }
 
 func (obj *gObject) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *gObject) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *gObject) ToJson() string {
@@ -959,12 +969,14 @@ func (obj *jObject) msg() *sanity.JObject {
 }
 
 func (obj *jObject) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *jObject) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *jObject) ToJson() string {
@@ -1013,12 +1025,14 @@ func (obj *kObject) msg() *sanity.KObject {
 }
 
 func (obj *kObject) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *kObject) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *kObject) ToJson() string {
@@ -1067,12 +1081,14 @@ func (obj *lObject) msg() *sanity.LObject {
 }
 
 func (obj *lObject) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *lObject) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *lObject) ToJson() string {
@@ -1219,12 +1235,14 @@ func (obj *levelOne) msg() *sanity.LevelOne {
 }
 
 func (obj *levelOne) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *levelOne) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *levelOne) ToJson() string {
@@ -1273,12 +1291,14 @@ func (obj *mandate) msg() *sanity.Mandate {
 }
 
 func (obj *mandate) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *mandate) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *mandate) ToJson() string {
@@ -1320,12 +1340,14 @@ func (obj *ipv4Pattern) msg() *sanity.Ipv4Pattern {
 }
 
 func (obj *ipv4Pattern) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *ipv4Pattern) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *ipv4Pattern) ToJson() string {
@@ -1363,12 +1385,14 @@ func (obj *ipv6Pattern) msg() *sanity.Ipv6Pattern {
 }
 
 func (obj *ipv6Pattern) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *ipv6Pattern) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *ipv6Pattern) ToJson() string {
@@ -1406,12 +1430,14 @@ func (obj *macPattern) msg() *sanity.MacPattern {
 }
 
 func (obj *macPattern) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *macPattern) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *macPattern) ToJson() string {
@@ -1449,12 +1475,14 @@ func (obj *integerPattern) msg() *sanity.IntegerPattern {
 }
 
 func (obj *integerPattern) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *integerPattern) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *integerPattern) ToJson() string {
@@ -1492,12 +1520,14 @@ func (obj *checksumPattern) msg() *sanity.ChecksumPattern {
 }
 
 func (obj *checksumPattern) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *checksumPattern) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *checksumPattern) ToJson() string {
@@ -1535,12 +1565,14 @@ func (obj *levelTwo) msg() *sanity.LevelTwo {
 }
 
 func (obj *levelTwo) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *levelTwo) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *levelTwo) ToJson() string {
@@ -1578,12 +1610,14 @@ func (obj *levelFour) msg() *sanity.LevelFour {
 }
 
 func (obj *levelFour) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *levelFour) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *levelFour) ToJson() string {
@@ -1621,12 +1655,14 @@ func (obj *patternIpv4PatternIpv4) msg() *sanity.PatternIpv4PatternIpv4 {
 }
 
 func (obj *patternIpv4PatternIpv4) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternIpv4PatternIpv4) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternIpv4PatternIpv4) ToJson() string {
@@ -1705,12 +1741,14 @@ func (obj *patternIpv6PatternIpv6) msg() *sanity.PatternIpv6PatternIpv6 {
 }
 
 func (obj *patternIpv6PatternIpv6) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternIpv6PatternIpv6) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternIpv6PatternIpv6) ToJson() string {
@@ -1789,12 +1827,14 @@ func (obj *patternMacPatternMac) msg() *sanity.PatternMacPatternMac {
 }
 
 func (obj *patternMacPatternMac) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternMacPatternMac) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternMacPatternMac) ToJson() string {
@@ -1873,12 +1913,14 @@ func (obj *patternIntegerPatternInteger) msg() *sanity.PatternIntegerPatternInte
 }
 
 func (obj *patternIntegerPatternInteger) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternIntegerPatternInteger) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternIntegerPatternInteger) ToJson() string {
@@ -1957,12 +1999,14 @@ func (obj *patternChecksumPatternChecksum) msg() *sanity.PatternChecksumPatternC
 }
 
 func (obj *patternChecksumPatternChecksum) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternChecksumPatternChecksum) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternChecksumPatternChecksum) ToJson() string {
@@ -2004,12 +2048,14 @@ func (obj *levelThree) msg() *sanity.LevelThree {
 }
 
 func (obj *levelThree) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *levelThree) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *levelThree) ToJson() string {
@@ -2051,12 +2097,14 @@ func (obj *patternIpv4PatternIpv4Counter) msg() *sanity.PatternIpv4PatternIpv4Co
 }
 
 func (obj *patternIpv4PatternIpv4Counter) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternIpv4PatternIpv4Counter) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternIpv4PatternIpv4Counter) ToJson() string {
@@ -2128,12 +2176,14 @@ func (obj *patternIpv6PatternIpv6Counter) msg() *sanity.PatternIpv6PatternIpv6Co
 }
 
 func (obj *patternIpv6PatternIpv6Counter) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternIpv6PatternIpv6Counter) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternIpv6PatternIpv6Counter) ToJson() string {
@@ -2205,12 +2255,14 @@ func (obj *patternMacPatternMacCounter) msg() *sanity.PatternMacPatternMacCounte
 }
 
 func (obj *patternMacPatternMacCounter) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternMacPatternMacCounter) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternMacPatternMacCounter) ToJson() string {
@@ -2282,12 +2334,14 @@ func (obj *patternIntegerPatternIntegerCounter) msg() *sanity.PatternIntegerPatt
 }
 
 func (obj *patternIntegerPatternIntegerCounter) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *patternIntegerPatternIntegerCounter) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *patternIntegerPatternIntegerCounter) ToJson() string {
@@ -2359,12 +2413,14 @@ func (obj *setConfigResponseStatusCode200) msg() *sanity.SetConfigResponse_Statu
 }
 
 func (obj *setConfigResponseStatusCode200) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *setConfigResponseStatusCode200) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *setConfigResponseStatusCode200) ToJson() string {
@@ -2391,12 +2447,14 @@ func (obj *updateConfigResponseStatusCode200) msg() *sanity.UpdateConfigResponse
 }
 
 func (obj *updateConfigResponseStatusCode200) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *updateConfigResponseStatusCode200) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *updateConfigResponseStatusCode200) ToJson() string {
@@ -2423,12 +2481,14 @@ func (obj *getConfigResponseStatusCode200) msg() *sanity.GetConfigResponse_Statu
 }
 
 func (obj *getConfigResponseStatusCode200) ToYaml() string {
-	data, _ := yaml.Marshal(obj.msg())
+	data, _ := json.Marshal(obj.msg())
+	data, _ = yaml.JSONToYAML(data)
 	return string(data)
 }
 
 func (obj *getConfigResponseStatusCode200) FromYaml(value string) error {
-	return yaml.Unmarshal([]byte(value), obj.msg())
+	data, _ := yaml.YAMLToJSON([]byte(value))
+	return json.Unmarshal([]byte(data), obj.msg())
 }
 
 func (obj *getConfigResponseStatusCode200) ToJson() string {

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -66,6 +66,8 @@ func TestYamlSerialization(t *testing.T) {
 func TestNewPrefixConfigSimpleTypes(t *testing.T) {
 	api := NewApi()
 	config := api.NewPrefixConfig()
+	config.SetIeee8021Qbb(true)
+	config.SetFullDuplex100Mb(2)
 	config.SetA("simple string")
 	config.SetB(12.2)
 	config.SetC(-33)


### PR DESCRIPTION
What: The yaml serialization was not using the correct model field names in serialization. This PR addresses that by using a more effective yaml serialization package. 