### PR TITLE
Fix generated go ux sdk required properties

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -500,22 +500,18 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     type=field.type,
                 )
         elif field.struct is not None:
-            if field.isPointer:
-                body = """if obj.obj.{name} == nil {{
-                        obj.obj.{name} = &{pb_pkg_name}.{pb_struct}{{}}
-                    }}
-                    return &{struct}{{obj: obj.obj.{name}}}
-                """.format(
-                    name=field.name,
-                    pb_pkg_name=self._protobuf_package_name,
-                    pb_struct=field.external_struct,
-                    struct=field.struct,
-                )
-            else:
-                body = "return &{struct}{{obj: obj.obj.{name}}}".format(
-                    struct=field.struct,
-                    name=field.name,
-                )
+            # at this time proto generation ignores the optional keyword 
+            # if the type is an object
+            body = """if obj.obj.{name} == nil {{
+                    obj.obj.{name} = &{pb_pkg_name}.{pb_struct}{{}}
+                }}
+                return &{struct}{{obj: obj.obj.{name}}}
+            """.format(
+                name=field.name,
+                pb_pkg_name=self._protobuf_package_name,
+                pb_struct=field.external_struct,
+                struct=field.struct,
+            )
         elif field.isPointer:
             body = """return *obj.obj.{name}""".format(name=field.name)
         else:

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -3,8 +3,16 @@ components:
     Prefix.Config:
       x-include:
       - '../common/common.yaml#/components/schemas/GlobalObject'
-      required: [response, a, b, c]
+      required: [response, a, b, c, required_object]
       properties:
+        required_object:
+          description: |-
+            A required object that MUST be generated as such.
+          $ref: '#/components/schemas/EObject'
+        optional_object:
+          description: |-
+            An optional object that MUST be generated as such.
+          $ref: '#/components/schemas/EObject'
         ieee_802_1qbb:
           type: boolean
         space_1:

--- a/openapiart/tests/server.py
+++ b/openapiart/tests/server.py
@@ -10,39 +10,31 @@ import pytest
 
 
 app = Flask(__name__)
-CONFIG = None
+app.CONFIG = None
+app.PACKAGE = None
 
-@app.route('/config', methods=['POST'])
+
+@app.route("/config", methods=["POST"])
 def set_config():
-    global CONFIG
-    # TODO Shall change the below sanity path to be dynamic
-    pkg_name = 'sanity'
-    lib_path = '../../.output/openapiart/%s' % pkg_name
-    sys.path.append(os.path.join(os.path.join(os.path.dirname(__file__), lib_path)))
-    package = importlib.import_module(pkg_name)
-    config = package.Api().prefix_config()
-    config.deserialize(request.data.decode('utf-8'))
+    config = app.PACKAGE.Api().prefix_config()
+    config.deserialize(request.data.decode("utf-8"))
     test = config.h
     if test is not None and isinstance(test, bool) is False:
-        return Response(status=590,
-                        response=json.dumps({'detail': 'invalid data type'}),
-                        headers={'Content-Type': 'application/json'})
+        return Response(status=590, response=json.dumps({"detail": "invalid data type"}), headers={"Content-Type": "application/json"})
     else:
-        CONFIG = config
+        app.CONFIG = config
         return Response(status=200)
 
 
-@app.route('/config', methods=['GET'])
+@app.route("/config", methods=["GET"])
 def get_config():
-    global CONFIG
-    return Response(CONFIG.serialize() if CONFIG is not None else '{}',
-                    mimetype='application/json',
-                    status=200)
+    serialized_config = app.CONFIG.serialize()
+    return Response(serialized_config, mimetype="application/json", status=200)
 
 
 @app.after_request
 def after_request(resp):
-    print(request.method, request.url, ' -> ', resp.status)
+    print(request.method, request.url, " -> ", resp.status)
     return resp
 
 
@@ -52,8 +44,12 @@ def web_server():
 
 class OpenApiServer(object):
     def __init__(self, package):
-        self._CONFIG = None
-        self.package = package
+        # TODO Shall change the below sanity path to be dynamic
+        pkg_name = "sanity"
+        lib_path = "../../.output/openapiart/%s" % pkg_name
+        sys.path.append(os.path.join(os.path.join(os.path.dirname(__file__), lib_path)))
+        app.PACKAGE = importlib.import_module(pkg_name)
+        app.CONFIG = app.PACKAGE.Api().prefix_config()
 
     def start(self):
         self._web_server_thread = threading.Thread(target=web_server)
@@ -63,11 +59,11 @@ class OpenApiServer(object):
         return self
 
     def _wait_until_ready(self):
-        api = self.package.api(location='http://127.0.0.1:80')
+        api = app.PACKAGE.api(location="http://127.0.0.1:80")
         while True:
             try:
                 api.get_config()
                 break
-            except Exception:
-                pass
-            time.sleep(.1)
+            except Exception as e:
+                print(e)
+            time.sleep(0.1)

--- a/pkg/unit_test.go
+++ b/pkg/unit_test.go
@@ -153,3 +153,29 @@ func TestLObject(t *testing.T) {
 	assert.Equal(t, "0x12", config.L().Hex())
 	log.Print(l.ToJson(), l.ToYaml())
 }
+
+// TestRequiredObject
+//  This test MUST create the underlying protobuf EObject
+//  The generated wrapper get accessor must create the underlying protobuf EObject
+//  Confirm the underlying protobuf EObject has been created by setting the
+//  properties of the returned RequiredObject
+func TestRequiredObject(t *testing.T) {
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	r := config.RequiredObject()
+	r.SetEA(22.2)
+	r.SetEB(66.1)
+}
+
+// TestOptionalObject
+//  This test MUST create the underlying protobuf EObject
+//  The generated wrapper get accessor must create the underlying protobuf EObject
+//  Confirm the underlying protobuf EObject has been created by setting the
+//  properties of the returned OptionalObject
+func TestOptionalObject(t *testing.T) {
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	r := config.OptionalObject()
+	r.SetEA(22.2)
+	r.SetEB(66.1)
+}


### PR DESCRIPTION
see issue #121 

Fix: go generation of required properties should check for underlying nil and create if it doesn't exist. 