### PR TITLE
Fix to return interface in NewApi func

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -36,6 +36,7 @@ class FluentRpcResponse(object):
         self.schema = None
         self.request_return_type = None
 
+
 class FluentHttp(object):
     """httpSetConfig(config Config) error"""
 
@@ -45,6 +46,7 @@ class FluentHttp(object):
         self.request = None
         self.request_return_type = None
         self.responses = []
+
 
 class FluentNew(object):
     """New<external_interface_name> <external_interface_name>"""
@@ -215,7 +217,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
     def _get_internal_name(self, openapi_name):
         name = self._get_external_struct_name(openapi_name)
         name = name[0].lower() + name[1:]
-        if name in ['error']:
+        if name in ["error"]:
             name = "_" + name
         return name
 
@@ -294,17 +296,12 @@ class OpenApiArtGo(OpenApiArtPlugin):
                         operation_name=rpc.operation_name,
                         struct=new.struct,
                     )
-                    if url.startswith('/'):
+                    if url.startswith("/"):
                         url = url[1:]
                     http.request = """api.httpSendRecv("{url}", {struct}.ToJson(), "{method}")""".format(
-                        operation_name=http.operation_name,
-                        url=url,
-                        struct=new.struct,
-                        method=str(operation_id.context.path.fields[0]).upper()
+                        operation_name=http.operation_name, url=url, struct=new.struct, method=str(operation_id.context.path.fields[0]).upper()
                     )
-                    http.method = """http{rpc_method}""".format(
-                        rpc_method=rpc.method
-                    )
+                    http.method = """http{rpc_method}""".format(rpc_method=rpc.method)
                 else:
                     rpc.method = """{operation_name}() ({request_return_type}, error)""".format(
                         operation_name=rpc.operation_name,
@@ -314,13 +311,8 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     rpc.http_call = """return api.http{operation_name}()""".format(
                         operation_name=rpc.operation_name,
                     )
-                    http.request = """api.httpSendRecv("{url}", "", "{method}")""".format(
-                        url=url,
-                        method=str(operation_id.context.path.fields[0]).upper()
-                    )
-                    http.method = """http{rpc_method}""".format(
-                        rpc_method=rpc.method
-                    )
+                    http.request = """api.httpSendRecv("{url}", "", "{method}")""".format(url=url, method=str(operation_id.context.path.fields[0]).upper())
+                    http.method = """http{rpc_method}""".format(rpc_method=rpc.method)
                 for ref in self._get_parser("$..responses").find(path_item_object):
                     for status_code, response_object in ref.value.items():
                         response = FluentRpcResponse()
@@ -352,7 +344,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
             }}
 
             // NewApi returns a new instance of the top level interface hierarchy
-            func NewApi() *{internal_struct_name} {{
+            func NewApi() {interface} {{
                 api := {internal_struct_name}{{}}
                 return &api
             }}
@@ -394,6 +386,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
             }}            
             """.format(
                 internal_struct_name=self._api.internal_struct_name,
+                interface=self._api.external_interface_name,
                 pb_pkg_name=self._protobuf_package_name,
             )
         )
@@ -475,7 +468,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     operation_response_name=self._get_internal_name(rpc.operation_name),
                     error_handling=error_handling,
                     return_value=return_value,
-                    http_call=rpc.http_call
+                    http_call=rpc.http_call,
                 )
             )
 
@@ -498,8 +491,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     }}
                     return dest.Bytes, nil
                 """.format(
-                    package_name=self._protobuf_package_name,
-                    operation_name=http.operation_name
+                    package_name=self._protobuf_package_name, operation_name=http.operation_name
                 )
             else:
                 success_handling = """	var dest {request_return_type}
@@ -569,7 +561,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 new.schema_name = self._get_external_struct_name(new.interface)
                 new.isRpcResponse = True
                 self._api.external_new_methods.append(new)
-                
+
     def _build_interface(self, new):
         if new.schema_name in self._api.components:
             new = self._api.components[new.schema_name]

--- a/pkg/mock_grpcserver_test.go
+++ b/pkg/mock_grpcserver_test.go
@@ -12,45 +12,47 @@ import (
 	"google.golang.org/grpc"
 )
 
-var (
-	testPort   uint         = 40051
-	testServer *grpc.Server = nil
-	config     *sanity.PrefixConfig
-)
-
-type server struct {
+type GrpcServer struct {
 	sanity.UnimplementedOpenapiServer
+	Location string
+	Server   *grpc.Server
+	Config   *sanity.PrefixConfig
 }
 
-func StartMockServer() error {
-	if testServer != nil {
-		log.Print("MockServer: Server already running")
+var (
+	grpcServer GrpcServer = GrpcServer{
+		Location: "[::]:40051",
+		Server:   nil,
+	}
+)
+
+func StartMockGrpcServer() error {
+	if grpcServer.Server != nil {
+		log.Print("MockGrpcServer: Server already running")
 		return nil
 	}
 
-	addr := fmt.Sprintf("[::]:%d", testPort)
-	lis, err := net.Listen("tcp", addr)
+	lis, err := net.Listen("tcp", grpcServer.Location)
 	if err != nil {
-		log.Fatal(fmt.Sprintf("MockServer: Server failed to listen on address %s", addr))
+		log.Fatal(fmt.Sprintf("MockGrpcServer: Server failed to listen on address %s", grpcServer.Location))
 	}
 
-	svr := grpc.NewServer()
-	log.Print(fmt.Sprintf("MockServer: Server started and listening on address %s", addr))
+	grpcServer.Server = grpc.NewServer()
+	log.Print(fmt.Sprintf("MockGrpcServer: Server started and listening on address %s", grpcServer.Location))
 
-	sanity.RegisterOpenapiServer(svr, &server{})
-	log.Print("MockServer: Server subscribed with gRPC Protocol Service")
+	sanity.RegisterOpenapiServer(grpcServer.Server, &grpcServer)
+	log.Print("MockGrpcServer: Server subscribed with gRPC Protocol Service")
 
 	go func() {
-		if err := svr.Serve(lis); err != nil {
-			log.Fatal("MockServer: Server failed to serve for incoming gRPC request.")
+		if err := grpcServer.Server.Serve(lis); err != nil {
+			log.Fatal("MockGrpcServer: Server failed to serve for incoming gRPC request.")
 		}
 	}()
 
-	testServer = svr
 	return nil
 }
 
-func (s *server) SetConfig(ctx context.Context, req *sanity.SetConfigRequest) (*sanity.SetConfigResponse, error) {
+func (s *GrpcServer) SetConfig(ctx context.Context, req *sanity.SetConfigRequest) (*sanity.SetConfigResponse, error) {
 	var resp *sanity.SetConfigResponse
 	switch req.PrefixConfig.Response.Enum().Number() {
 	case sanity.PrefixConfig_Response_status_400.Enum().Number():
@@ -70,7 +72,7 @@ func (s *server) SetConfig(ctx context.Context, req *sanity.SetConfigRequest) (*
 			},
 		}
 	case sanity.PrefixConfig_Response_status_200.Enum().Number():
-		config = req.PrefixConfig
+		s.Config = req.PrefixConfig
 		resp = &sanity.SetConfigResponse{
 			StatusCode_200: &sanity.SetConfigResponse_StatusCode200{
 				Bytes: []byte("SetConfig has completed successfully"),
@@ -80,19 +82,19 @@ func (s *server) SetConfig(ctx context.Context, req *sanity.SetConfigRequest) (*
 	return resp, nil
 }
 
-func (s *server) GetConfig(ctx context.Context, req *empty.Empty) (*sanity.GetConfigResponse, error) {
+func (s *GrpcServer) GetConfig(ctx context.Context, req *empty.Empty) (*sanity.GetConfigResponse, error) {
 	resp := &sanity.GetConfigResponse{
 		StatusCode_200: &sanity.GetConfigResponse_StatusCode200{
-			PrefixConfig: config,
+			PrefixConfig: s.Config,
 		},
 	}
 	return resp, nil
 }
 
-func (s *server) UpdateConfig(ctx context.Context, req *sanity.UpdateConfigRequest) (*sanity.UpdateConfigResponse, error) {
+func (s *GrpcServer) UpdateConfig(ctx context.Context, req *sanity.UpdateConfigRequest) (*sanity.UpdateConfigResponse, error) {
 	resp := &sanity.UpdateConfigResponse{
 		StatusCode_200: &sanity.UpdateConfigResponse_StatusCode200{
-			PrefixConfig: config,
+			PrefixConfig: s.Config,
 		},
 	}
 	return resp, nil

--- a/pkg/mock_httpserver_test.go
+++ b/pkg/mock_httpserver_test.go
@@ -6,21 +6,25 @@ import (
 	"log"
 	"net/http"
 
-	art "github.com/open-traffic-generator/openapiart/pkg"
+	. "github.com/open-traffic-generator/openapiart/pkg"
 )
 
 type HttpServer struct {
-	Api    art.OpenapiartApi
-	Config art.PrefixConfig
+	serverLocation string
+	Location       string
+	Api            OpenapiartApi
+	Config         PrefixConfig
 }
 
 var (
-	httpTestPort uint       = 50051
-	httpServer   HttpServer = HttpServer{}
+	httpServer HttpServer = HttpServer{
+		serverLocation: "127.0.0.1:50051",
+	}
 )
 
 func StartMockHttpServer() {
-	httpServer.Api = art.NewApi()
+	httpServer.Location = fmt.Sprintf("http://%s", httpServer.serverLocation)
+	httpServer.Api = NewApi()
 	httpServer.Config = httpServer.Api.NewPrefixConfig()
 
 	http.HandleFunc("/config", func(w http.ResponseWriter, r *http.Request) {
@@ -50,10 +54,10 @@ func StartMockHttpServer() {
 			w.Write([]byte(response.ToJson()))
 		}
 	})
-	server_path := fmt.Sprintf("127.0.0.1:%d", httpTestPort)
-	log.Fatal(http.ListenAndServe(server_path, nil))
-}
 
-// func init() {
-// 	go StartMockHttpServer()
-// }
+	go func() {
+		if err := http.ListenAndServe(httpServer.serverLocation, nil); err != nil {
+			log.Fatal("Server failed to serve incoming HTTP request.")
+		}
+	}()
+}

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -1,8 +1,6 @@
 package openapiart_test
 
 import (
-	"fmt"
-	"log"
 	"testing"
 
 	openapiart "github.com/open-traffic-generator/openapiart/pkg"
@@ -10,172 +8,49 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var apis []openapiart.OpenapiartApi
+
 func init() {
-	if err := StartMockServer(); err != nil {
-		log.Fatal("Mock Server Init failed")
-	}
-	go StartMockHttpServer()
-}
-
-func TestApi(t *testing.T) {
-	api := openapiart.NewApi()
-	assert.NotNil(t, api)
-}
-
-func TestGrpcTransport(t *testing.T) {
-	location := "127.0.0.1:5050"
-	timeout := 10
-	api := openapiart.NewApi()
-	transport := api.NewGrpcTransport().SetLocation("127.0.0.1:5050").SetRequestTimeout(10)
-	assert.NotNil(t, transport)
-	assert.NotNil(t, transport.Location(), location)
-	assert.NotNil(t, transport.RequestTimeout(), timeout)
-}
-
-func TestHttpTransport(t *testing.T) {
-	location := "https://127.0.0.1:5050"
-	verify := false
-	api := openapiart.NewApi()
-	transport := api.NewHttpTransport().SetLocation(location).SetVerify(verify)
-	assert.NotNil(t, transport)
-	assert.NotNil(t, transport.Location(), location)
-	assert.NotNil(t, transport.Verify(), verify)
-}
-
-func TestNewPrefixConfig(t *testing.T) {
-	api := openapiart.NewApi()
-	config := api.NewPrefixConfig()
-	assert.NotNil(t, config)
-}
-
-func TestPrefixConfigSetName(t *testing.T) {
-	config := openapiart.NewApi().NewPrefixConfig()
-	name := "asdfasdf"
-	config.SetName(name)
-	assert.Equal(t, name, config.Name())
-}
-
-func TestNewPrefixConfigSimpleTypes(t *testing.T) {
-	api := openapiart.NewApi()
-	config := api.NewPrefixConfig()
-	config.SetIeee8021Qbb(true)
-	config.SetFullDuplex100Mb(2)
-	config.SetA("simple string")
-	config.SetB(12.2)
-	config.SetC(-33)
-	config.SetH(true)
-	config.SetI([]byte("a simple byte string"))
-	config.SetName("name string")
-	assert.NotNil(t, config)
-	fmt.Println(config.ToYaml())
-}
-
-func TestGetObject(t *testing.T) {
-	config := openapiart.NewApi().NewPrefixConfig()
-	e := config.SetName("PrefixConfig Name").E().SetName("E Name")
-	f := config.F().SetFA("a f_a value")
-	assert.NotNil(t, config.E().Name())
-	assert.NotNil(t, e.Name())
-	assert.Equal(t, e.Name(), config.E().Name())
-	assert.Equal(t, f.FA(), config.F().FA())
-	fmt.Println(config.ToYaml())
-}
-
-func TestAddObject(t *testing.T) {
-	config := openapiart.NewApi().NewPrefixConfig()
-	config.G().Add().SetName("G1").SetGA("ga string").SetGB(232)
-	config.G().Add().SetName("G2")
-	config.G().Add().SetName("G3").SetGA("3 is not 2 or 1 or none")
-	config.J().Add().JB().SetFA("a FA string")
-	config.J().Add().JA().SetEA(22.2)
-	for _, item := range config.G().Items() {
-		fmt.Println(item.Name())
-	}
-	name := "new persistent name"
-	config.G().Items()[1].SetName(name)
-	assert.Equal(t, len(config.G().Items()), 3)
-	assert.Equal(t, config.G().Items()[1].Name(), name)
-	fmt.Println(config.ToYaml())
+	StartMockGrpcServer()
+	StartMockHttpServer()
+	grpcApi := openapiart.NewApi()
+	grpcApi.NewGrpcTransport().SetLocation(grpcServer.Location)
+	apis = append(apis, grpcApi)
+	httpApi := openapiart.NewApi()
+	httpApi.NewHttpTransport().SetLocation(httpServer.Location)
+	apis = append(apis, httpApi)
 }
 
 func TestSetConfigSuccess(t *testing.T) {
-	api := openapiart.NewApi()
-	api.NewGrpcTransport().SetLocation(fmt.Sprintf("127.0.0.1:%d", testPort))
-	config := NewFullyPopulatedPrefixConfig(api)
-	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
-	resp, err := api.SetConfig(config)
-	assert.Nil(t, err)
-	assert.NotNil(t, resp)
+	for _, api := range apis {
+		config := NewFullyPopulatedPrefixConfig(api)
+		config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+		resp, err := api.SetConfig(config)
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
+	}
 }
 
 func TestGetConfigSuccess(t *testing.T) {
-	api := openapiart.NewApi()
-	api.NewGrpcTransport().SetLocation(fmt.Sprintf("127.0.0.1:%d", testPort))
-	config := NewFullyPopulatedPrefixConfig(api)
-	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
-	api.SetConfig(config)
-	resp, err := api.GetConfig()
-	fmt.Println(resp.ToYaml())
-	assert.Nil(t, err)
-	assert.NotNil(t, resp)
+	for _, api := range apis {
+		config := NewFullyPopulatedPrefixConfig(api)
+		config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+		api.SetConfig(config)
+		resp, err := api.GetConfig()
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
+	}
 }
 
 func TestUpdateConfigSuccess(t *testing.T) {
-	api := openapiart.NewApi()
-	api.NewGrpcTransport().SetLocation(fmt.Sprintf("127.0.0.1:%d", testPort))
-
-	config := NewFullyPopulatedPrefixConfig(api)
-	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
-	api.SetConfig(config)
-	c := api.NewUpdateConfig()
-	c.G().Add().SetName("G1").SetGA("ga string").SetGB(232)
-	updatedConfig, err := api.UpdateConfig(c)
-	assert.Nil(t, err)
-	assert.NotNil(t, updatedConfig)
-	fmt.Println(updatedConfig.ToYaml())
-}
-
-func TestHttpSetConfigSuccess(t *testing.T) {
-	location := fmt.Sprintf("http://127.0.0.1:%d", httpTestPort)
-	verify := false
-	api := openapiart.NewApi()
-	api.NewHttpTransport().SetLocation(location).SetVerify(verify)
-
-	config := NewFullyPopulatedPrefixConfig(api)
-	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
-	resp, err := api.SetConfig(config)
-	assert.Nil(t, err)
-	assert.NotNil(t, resp)
-}
-
-func TestHttpGetConfigSuccess(t *testing.T) {
-	location := fmt.Sprintf("http://127.0.0.1:%d", httpTestPort)
-	verify := false
-	api := openapiart.NewApi()
-	api.NewHttpTransport().SetLocation(location).SetVerify(verify)
-
-	config := NewFullyPopulatedPrefixConfig(api)
-	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
-	api.SetConfig(config)
-	resp, err := api.GetConfig()
-	fmt.Println(resp.ToYaml())
-	assert.Nil(t, err)
-	assert.NotNil(t, resp)
-}
-
-func TestHttpUpdateConfigSuccess(t *testing.T) {
-	location := fmt.Sprintf("http://127.0.0.1:%d", httpTestPort)
-	verify := false
-	api := openapiart.NewApi()
-	api.NewHttpTransport().SetLocation(location).SetVerify(verify)
-
-	config := NewFullyPopulatedPrefixConfig(api)
-	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
-	api.SetConfig(config)
-	c := api.NewUpdateConfig()
-	c.G().Add().SetName("G1").SetGA("ga string").SetGB(232)
-	updatedConfig, err := api.UpdateConfig(c)
-	assert.Nil(t, err)
-	assert.NotNil(t, updatedConfig)
-	fmt.Println(updatedConfig.ToYaml())
+	for _, api := range apis {
+		config := NewFullyPopulatedPrefixConfig(api)
+		config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+		api.SetConfig(config)
+		c := api.NewUpdateConfig()
+		c.G().Add().SetName("G1").SetGA("ga string").SetGB(232)
+		updatedConfig, err := api.UpdateConfig(c)
+		assert.Nil(t, err)
+		assert.NotNil(t, updatedConfig)
+	}
 }


### PR DESCRIPTION
Issue: NewApi func returns a pointer to the the internal struct

Fix: This PR changes the return type of NewApi to the interface  