### PR TITLE
Http success response fix and test case

### DIFF
--- a/openapiart/tests/api/api.yaml
+++ b/openapiart/tests/api/api.yaml
@@ -66,3 +66,15 @@ paths:
             application/json:
               schema:
                 $ref: '../config/config.yaml#/components/schemas/Metrics'
+
+  /warnings:
+    get:
+      tags: ['Metrics']
+      operationId: get_warnings
+      description: >-
+        Gets warnings.
+      responses:
+        x-include:
+        - '../common/common.yaml#/components/responses/Warnings'
+        - '../common/common.yaml#/components/responses/Error.400'
+        - '../common/common.yaml#/components/responses/Error500'

--- a/openapiart/tests/common/common.yaml
+++ b/openapiart/tests/common/common.yaml
@@ -31,6 +31,13 @@ components:
           type: array
           items:
             type: string
+    Warning.Details:
+      type: object
+      properties:
+        warnings:
+          type: array
+          items:
+            type: string
 
   responses:
     Success:
@@ -41,6 +48,13 @@ components:
             schema:
               type: string
               format: binary
+    Warnings:
+      '200':
+        description: 'Success warning payload'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Warning.Details'
     Error.400:
       '400':
         description: 'error 4xx'

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -102,6 +102,14 @@ components:
           $ref: '../pattern/pattern.yaml#/components/schemas/IntegerPattern'
         checksum_pattern:
           $ref: '../pattern/pattern.yaml#/components/schemas/ChecksumPattern'
+        case:
+          $ref: '#/components/schemas/Layer1Ieee802x'
+        
+    Layer1Ieee802x:
+      type: object
+      properties:
+        flow_control:
+          type: boolean
           
     GObject:
       x-include:

--- a/pkg/mock_grpcserver_test.go
+++ b/pkg/mock_grpcserver_test.go
@@ -124,3 +124,14 @@ func (s *GrpcServer) GetMetrics(ctx context.Context, empty *emptypb.Empty) (*san
 	}
 	return resp, nil
 }
+
+func (s *GrpcServer) GetWarnings(ctx context.Context, empty *empty.Empty) (*sanity.GetWarningsResponse, error) {
+	resp := &sanity.GetWarningsResponse{
+		StatusCode_200: &sanity.GetWarningsResponse_StatusCode200{
+			WarningDetails: &sanity.WarningDetails{
+				Warnings: []string{"Warning number 1", "Your last warning"},
+			},
+		},
+	}
+	return resp, nil
+}

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -32,6 +32,26 @@ func TestSetConfigSuccess(t *testing.T) {
 	}
 }
 
+func TestSetConfig400(t *testing.T) {
+	for _, api := range apis {
+		config := NewFullyPopulatedPrefixConfig(api)
+		config.SetResponse(openapiart.PrefixConfigResponse.STATUS_400)
+		resp, err := api.SetConfig(config)
+		assert.Nil(t, resp)
+		assert.NotNil(t, err)
+	}
+}
+
+func TestSetConfig500(t *testing.T) {
+	for _, api := range apis {
+		config := NewFullyPopulatedPrefixConfig(api)
+		config.SetResponse(openapiart.PrefixConfigResponse.STATUS_500)
+		resp, err := api.SetConfig(config)
+		assert.Nil(t, resp)
+		assert.NotNil(t, err)
+	}
+}
+
 func TestGetConfigSuccess(t *testing.T) {
 	for _, api := range apis {
 		config := NewFullyPopulatedPrefixConfig(api)
@@ -64,5 +84,14 @@ func TestGetMetrics(t *testing.T) {
 		for _, row := range metrics.Ports().Items() {
 			log.Println(row.ToYaml())
 		}
+	}
+}
+
+func TestGetWarnings(t *testing.T) {
+	for _, api := range apis {
+		resp, err := api.GetWarnings()
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
+		log.Println(resp.ToYaml())
 	}
 }


### PR DESCRIPTION
fixes issue #161 

Validation: Added test cases for both go transports (grpc/http)
- for 200 success with warnings `TestGetWarnings`
- for 400 error `TestSetConfig400`
- for 500 error `TestSetConfig500`
