### PR TITLE
Fix proto and go response generation

### DIFF
--- a/openapiart/tests/api/api.yaml
+++ b/openapiart/tests/api/api.yaml
@@ -74,7 +74,5 @@ paths:
       description: >-
         Gets warnings.
       responses:
-        x-include:
-        - '../common/common.yaml#/components/responses/Warnings'
-        - '../common/common.yaml#/components/responses/Error.400'
-        - '../common/common.yaml#/components/responses/Error500'
+        '200':
+          $ref: '../common/common.yaml#/components/responses/Warnings'

--- a/openapiart/tests/common/common.yaml
+++ b/openapiart/tests/common/common.yaml
@@ -49,12 +49,11 @@ components:
               type: string
               format: binary
     Warnings:
-      '200':
-        description: 'Success warning payload'
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Warning.Details'
+      description: 'Success warning payload similar to otg Success'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Warning.Details'
     Error.400:
       '400':
         description: 'error 4xx'

--- a/openapiart/tests/grpcserver.py
+++ b/openapiart/tests/grpcserver.py
@@ -14,18 +14,14 @@ def grpc_server(pb2, pb2_grpc):
             response_400 = """
                 {
                     "status_code_400" : {
-                        "error_details" : {
-                            "errors" : ["invalid value"]
-                        }
+                        "errors" : ["invalid value"]
                     }
                 }
                 """
 
             response_200 = """
                 {
-                    "status_code_200" : {
-                        "bytes" : "%s"
-                    }
+                    "status_code_200" : "%s"
                 }
             """ % base64.b64encode(
                 b"success"

--- a/openapiart/tests/test_grpc_response.py
+++ b/openapiart/tests/test_grpc_response.py
@@ -11,9 +11,7 @@ def test_grpc_response(utils, pb2, pb2_grpc):
     validate the response with expected response
     """
     expected_response = """{
-            "status_code_200": {
-                "bytes": "%s"
-            }
+            "status_code_200": "%s"
         }""" % base64.b64encode(b"success").decode('utf-8')
 
     # load the json from a file

--- a/pkg/mock_grpcserver_test.go
+++ b/pkg/mock_grpcserver_test.go
@@ -58,26 +58,20 @@ func (s *GrpcServer) SetConfig(ctx context.Context, req *sanity.SetConfigRequest
 	switch req.PrefixConfig.Response.Enum().Number() {
 	case sanity.PrefixConfig_Response_status_400.Enum().Number():
 		resp = &sanity.SetConfigResponse{
-			StatusCode_400: &sanity.SetConfigResponse_StatusCode400{
-				ErrorDetails: &sanity.ErrorDetails{
-					Errors: []string{"SetConfig has detected configuration errors"},
-				},
+			StatusCode_400: &sanity.ErrorDetails{
+				Errors: []string{"SetConfig has detected configuration errors"},
 			},
 		}
 	case sanity.PrefixConfig_Response_status_500.Enum().Number():
 		resp = &sanity.SetConfigResponse{
-			StatusCode_500: &sanity.SetConfigResponse_StatusCode500{
-				Error: &sanity.Error{
-					Errors: []string{"SetConfig has encountered a server error"},
-				},
+			StatusCode_500: &sanity.Error{
+				Errors: []string{"SetConfig has encountered a server error"},
 			},
 		}
 	case sanity.PrefixConfig_Response_status_200.Enum().Number():
 		s.Config = req.PrefixConfig
 		resp = &sanity.SetConfigResponse{
-			StatusCode_200: &sanity.SetConfigResponse_StatusCode200{
-				Bytes: []byte("SetConfig has completed successfully"),
-			},
+			StatusCode_200: []byte("SetConfig has completed successfully"),
 		}
 	}
 	return resp, nil
@@ -85,41 +79,33 @@ func (s *GrpcServer) SetConfig(ctx context.Context, req *sanity.SetConfigRequest
 
 func (s *GrpcServer) GetConfig(ctx context.Context, req *empty.Empty) (*sanity.GetConfigResponse, error) {
 	resp := &sanity.GetConfigResponse{
-		StatusCode_200: &sanity.GetConfigResponse_StatusCode200{
-			PrefixConfig: s.Config,
-		},
+		StatusCode_200: s.Config,
 	}
 	return resp, nil
 }
 
 func (s *GrpcServer) UpdateConfig(ctx context.Context, req *sanity.UpdateConfigRequest) (*sanity.UpdateConfigResponse, error) {
 	resp := &sanity.UpdateConfigResponse{
-		StatusCode_200: &sanity.UpdateConfigResponse_StatusCode200{
-			PrefixConfig: s.Config,
-		},
+		StatusCode_200: s.Config,
 	}
 	return resp, nil
 }
 
 func (s *GrpcServer) GetMetrics(ctx context.Context, empty *emptypb.Empty) (*sanity.GetMetricsResponse, error) {
-	metrics := sanity.Metrics{
-		Ports: []*sanity.PortMetric{},
-	}
-	p1 := sanity.PortMetric{
-		Name:     "P1",
-		TxFrames: 2323,
-		RxFrames: 2000,
-	}
-	p2 := sanity.PortMetric{
-		Name:     "P2",
-		TxFrames: 3000,
-		RxFrames: 2788,
-	}
-	metrics.Ports = append(metrics.Ports, &p1)
-	metrics.Ports = append(metrics.Ports, &p2)
 	resp := &sanity.GetMetricsResponse{
-		StatusCode_200: &sanity.GetMetricsResponse_StatusCode200{
-			Metrics: &metrics,
+		StatusCode_200: &sanity.Metrics{
+			Ports: []*sanity.PortMetric{
+				&sanity.PortMetric{
+					Name:     "P2",
+					TxFrames: 3000,
+					RxFrames: 2788,
+				},
+				&sanity.PortMetric{
+					Name:     "P1",
+					TxFrames: 2323,
+					RxFrames: 2000,
+				},
+			},
 		},
 	}
 	return resp, nil
@@ -127,10 +113,8 @@ func (s *GrpcServer) GetMetrics(ctx context.Context, empty *emptypb.Empty) (*san
 
 func (s *GrpcServer) GetWarnings(ctx context.Context, empty *empty.Empty) (*sanity.GetWarningsResponse, error) {
 	resp := &sanity.GetWarningsResponse{
-		StatusCode_200: &sanity.GetWarningsResponse_StatusCode200{
-			WarningDetails: &sanity.WarningDetails{
-				Warnings: []string{"Warning number 1", "Your last warning"},
-			},
+		StatusCode_200: &sanity.WarningDetails{
+			Warnings: []string{"This is your first warning", "Your last warning"},
 		},
 	}
 	return resp, nil

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -65,14 +65,15 @@ func TestGetConfigSuccess(t *testing.T) {
 
 func TestUpdateConfigSuccess(t *testing.T) {
 	for _, api := range apis {
-		config := NewFullyPopulatedPrefixConfig(api)
-		config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
-		api.SetConfig(config)
-		c := api.NewUpdateConfig()
-		c.G().Add().SetName("G1").SetGA("ga string").SetGB(232)
-		updatedConfig, err := api.UpdateConfig(c)
+		config1 := NewFullyPopulatedPrefixConfig(api)
+		config1.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+		api.SetConfig(config1)
+		config2 := api.NewUpdateConfig()
+		config2.G().Add().SetName("G1").SetGA("ga string").SetGB(232)
+		config3, err := api.UpdateConfig(config2)
 		assert.Nil(t, err)
-		assert.NotNil(t, updatedConfig)
+		assert.NotNil(t, config3)
+		log.Println(config3.ToYaml())
 	}
 }
 


### PR DESCRIPTION
Issue
-----
The generated .proto responses are too deeply nested and do not accurately mirror openapi responses.
The intent is to have <rpcmethod>Response messages encapsulate each openapi method's individual status codes.
This makes it easy to understand what to return if implementing a go grpc or go http server or an http server using opensource generated openapi server stubs. The opensource generated stubs are the standard for interop and MUST be honored. 

Generated .proto responses will bring the actual openapi content directly up to the status code.
This will cause `breakage in current grpc server implementations`.
Any `http implementations not using .proto` will function correctly.

This is a sample of the new proto response generation using open-traffic-generator models version 0.5.3
```proto
message SetConfigResponse {
  optional ResponseWarning status_code_200 = 1;
  optional ResponseError status_code_400 = 2;
  optional ResponseError status_code_500 = 3;
}

message GetConfigResponse {
  optional Config status_code_200 = 1;
  optional ResponseError status_code_400 = 2;
  optional ResponseError status_code_500 = 3;
}
```

Validation
-----------
Successfully ran all gotest and pytest test cases against .proto grpc server and http server
Also built gosnappi using open-traffic-generator models and ran unit tests against the latest athena http controller. 

