### PR TITLE
Remove redundant if condition in generated go code

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -495,12 +495,13 @@ class OpenApiArtGo(OpenApiArtPlugin):
             for response in http.responses:
                 if response.status_code.startswith("2"):
                     success_method = response.request_return_type
-                error_handling += """if resp.StatusCode == {status_code} {{
-                        return nil, fmt.Errorf(string(bodyBytes))
-                    }}
-                    """.format(
-                    status_code=response.status_code,
-                )
+                else:
+                    error_handling += """if resp.StatusCode == {status_code} {{
+                            return nil, fmt.Errorf(string(bodyBytes))
+                        }}
+                        """.format(
+                        status_code=response.status_code,
+                    )
             error_handling += 'return nil, fmt.Errorf("response not implemented")'
             if http.request_return_type == "[]byte":
                 success_handling = """return bodyBytes, nil""".format(package_name=self._protobuf_package_name, operation_name=http.operation_name)


### PR DESCRIPTION
Issue
-----
addresses issue #166 

Validation
-----------
Manually inspected generated code and the redundant if is no longer present
```go
func (api *openapiartApi) httpSetConfig(prefixConfig PrefixConfig) ([]byte, error) {
	resp, err := api.httpSendRecv("config", prefixConfig.ToJson(), "POST")
	if err != nil {
		return nil, err
	}
	bodyBytes, err := ioutil.ReadAll(resp.Body)
	defer resp.Body.Close()
	if err != nil {
		return nil, err
	}
	if resp.StatusCode == 200 {
		return bodyBytes, nil
	}
	if resp.StatusCode == 400 {
		return nil, fmt.Errorf(string(bodyBytes))
	}
	if resp.StatusCode == 500 {
		return nil, fmt.Errorf(string(bodyBytes))
	}
	return nil, fmt.Errorf("response not implemented")
}
```
