### PR TITLE
Merge x-status extension into description

### DIFF
--- a/MODELGUIDE.md
+++ b/MODELGUIDE.md
@@ -82,16 +82,24 @@ The build script will enforce the following keyword conventions.
         - the string value MUST be unique in the list of objects
   
 # Keyword Extensions
-- `x-status`: current | under-review | deprecated | obsolete
-  - If no status is specified, the default is "current".
-  - the `x-status` keyword takes as an argument one of the strings
-   "current", "deprecated", or "obsolete", "under-review.
-  - "current" means that the definition is current and valid.
-  - "deprecated" indicates an obsolete definition, but it permits new/
-      continued implementation in order to foster interoperability with
-      older/existing implementations.
-  - "obsolete" means the definition is obsolete and SHOULD NOT be
-      implemented and/or can be removed from implementations.
+- `x-status`
+```yaml
+components:
+  schemas:
+    Extensions:
+      properties:
+        x-status:
+          description: |-
+            An extension keyword to indicate the status of a schema object or property
+            - current means that the definition is current and valid.
+            - deprecated indicates an obsolete definition, but it permits new/ continued implementation in order to foster interoperability with older/existing implementations.
+            - `obsolete` means the definition is obsolete and SHOULD NOT be implemented and/or can be removed from implementations.
+            - `under-review` indicates that the object or property is subject to change at any time.
+          type: string
+          enum: [current, deprecated, obsolete, under_review]
+          default: current
+```
+
 
 - `x-include`
     - for object composition use the x-include keyword to merge schema objects 

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -26,11 +26,13 @@ components:
           enum: [status_200, status_400, status_500]
           default: status_200
         a:
+          x-status: under-review
           description: |-
             Small single line description
           type: string
           default: asdf
         b:
+          x-status: deprecated
           description: |-
             Longer multi-line description
             Second line is here


### PR DESCRIPTION
addresses issue #170 

Validation:
Added x-status keywords to sanity configuration and confirmed by manually inspecting openapi.yaml document.

```yaml
        a:
          x-status: under-review
          description: |-
            Status: under-review
            Small single line description
          type: string
          default: asdf
        b:
          x-status: deprecated
          description: |-
            Status: deprecated
            Longer multi-line description
            Second line is here
            Third line
          type: number
          format: float
          default: 65.0
```
 