### PR TITLE
Expose the msg method for use in server side applications

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -290,7 +290,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     new.method = """New{interface}() {interface}""".format(interface=new.interface)
                     if len([m for m in self._api.external_new_methods if m.schema_name == new.schema_name]) == 0:
                         self._api.external_new_methods.append(new)
-                    rpc.request = "{pb_pkg_name}.{operation_name}Request{{{interface}: {struct}.msg()}}".format(
+                    rpc.request = "{pb_pkg_name}.{operation_name}Request{{{interface}: {struct}.Msg()}}".format(
                         pb_pkg_name=self._protobuf_package_name,
                         operation_name=rpc.operation_name,
                         interface=new.interface,
@@ -590,16 +590,21 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 obj *{pb_pkg_name}.{interface}
             }}
             
-            func (obj *{struct}) msg() *{pb_pkg_name}.{interface} {{
+            func (obj *{struct}) Msg() *{pb_pkg_name}.{interface} {{
                 return obj.obj
             }}
 
+            func (obj *{struct}) SetMsg(msg *{pb_pkg_name}.{interface}) {interface} {{
+                obj.obj = msg
+                return obj
+            }}
+
             func (obj *{struct}) ToPbText() string {{
-                return proto.MarshalTextString(obj.msg())
+                return proto.MarshalTextString(obj.Msg())
             }}
 
             func (obj *{struct}) FromPbText(value string) error {{
-                return proto.UnmarshalText(value, obj.msg())
+                return proto.UnmarshalText(value, obj.Msg())
             }}
 
             func (obj *{struct}) ToYaml() string {{
@@ -608,7 +613,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     AllowPartial:    true,
                     EmitUnpopulated: false,
                 }}
-                data, err := opts.Marshal(obj.msg())
+                data, err := opts.Marshal(obj.Msg())
                 data, err = yaml.JSONToYAML(data)
                 if err != nil {{
                     panic(err)
@@ -625,7 +630,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     AllowPartial: true,
                     DiscardUnknown: false,
                 }}
-                return opts.Unmarshal([]byte(data), obj.msg())
+                return opts.Unmarshal([]byte(data), obj.Msg())
             }}
 
             func (obj *{struct}) ToJson() string {{
@@ -635,7 +640,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     EmitUnpopulated: false,
                     Indent:          "  ",
                 }}
-                data, err := opts.Marshal(obj.msg())
+                data, err := opts.Marshal(obj.Msg())
                 if err != nil {{
                     panic(err)
                 }}
@@ -647,7 +652,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     AllowPartial: true,
                     DiscardUnknown: false,
                 }}
-                return opts.Unmarshal([]byte(value), obj.msg())
+                return opts.Unmarshal([]byte(value), obj.Msg())
             }}
         """.format(
                 struct=new.struct,
@@ -673,7 +678,8 @@ class OpenApiArtGo(OpenApiArtPlugin):
         interface_signatures = "\n".join(interfaces)
         self._write(
             """type {interface} interface {{
-                msg() *{pb_pkg_name}.{interface}
+                Msg() *{pb_pkg_name}.{interface}
+                SetMsg(*{pb_pkg_name}.{interface}) {interface}
                 {interface_signatures}
             }}
         """.format(


### PR DESCRIPTION
# Issue
The ability to set/get the underlying protobuf message is needed for server side use of the library.

# Validation
All test cases pass that serialize using yaml.
Mock servers will be migrated at a later date. 