### PR TITLE
Fix go generation of validation code for required ipv4, ipv6, mac, hex fields

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -1242,8 +1242,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 // {name} required
                 if obj.obj.{name} == {value} {{
                     validation = append(validation, "{name} is required field on interface {interface}")
-                }}
-                """.format(
+                }}""".format(
                     name=field.name,
                     interface=new.interface,
                     value='""' if field.type == "string" else "nil",

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -198,6 +198,7 @@ components:
       description: |-
         Format validation object
       type: object
+      required: [ipv4]
       properties:
         string:
           type: string

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -106,7 +106,9 @@ components:
           $ref: '../pattern/pattern.yaml#/components/schemas/ChecksumPattern'
         case:
           $ref: '#/components/schemas/Layer1Ieee802x'
-        
+        m_object:
+          $ref: '#/components/schemas/MObject'
+
     Layer1Ieee802x:
       type: object
       properties:
@@ -198,7 +200,37 @@ components:
       description: |-
         Format validation object
       type: object
-      required: [ipv4]
+      properties:
+        string:
+          type: string
+        integer:
+          type: integer
+          minimum: 10
+          maximum: 90
+        float:
+          type: number
+          format: float
+        double:
+          type: number
+          format: double
+        mac:
+          type: string
+          format: mac
+        ipv4:
+          type: string
+          format: ipv4
+        ipv6:
+          type: string
+          format: ipv6
+        hex:
+          type: string
+          format: hex
+
+    MObject:
+      description: |-
+        Required format validation object
+      type: object
+      required: [string, integer, float, double, mac, ipv4, ipv6, hex]
       properties:
         string:
           type: string

--- a/pkg/unit_test.go
+++ b/pkg/unit_test.go
@@ -456,3 +456,20 @@ func TestDefaultFObject(t *testing.T) {
 	}`
 	require.JSONEq(t, actual_result, expected_result)
 }
+
+func TestRequiredValidation(t *testing.T) {
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	config.RequiredObject()
+	config.MObject().
+		SetString("asdf").
+		SetInteger(63).
+		SetDouble(55.4).
+		SetFloat(33.2).
+		SetHex("00AABB").
+		SetMac("00:AA:BB:CC:DD:EE").
+		SetIpv6("2001::1").
+		SetIpv4("1.1.1.1")
+	err := config.Validate()
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
### Issue
go generation for required ipv4, ipv6, mac, hex fields was producing invalid code with else statement on a separate line

### Validation
Added a MObject to config.yaml that has those fields as required. 
Go generated file has no errors.
Added a validation test for the MObject field. 