### PR TITLE
Bundler should accommodate numeric keys

### DIFF
--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -82,14 +82,14 @@ class Bundler(object):
         self._resolve_strings(self._content)
         with open(self._output_filename, "w") as fp:
             yaml.dump(self._content, fp, indent=2, allow_unicode=True, line_break="\n", sort_keys=False)
-        self._validate_file()
         with open(self._json_filename, "w") as fp:
             fp.write(json.dumps(self._content, indent=4))
+        self._validate_file()
 
     def _validate_file(self):
-        print("validating {}...".format(self._output_filename))
-        with open(self._output_filename) as fid:
-            yobject = yaml.safe_load(fid)
+        print("validating {}...".format(self._json_filename))
+        with open(self._json_filename) as fid:
+            yobject = json.load(fid)
             openapi_spec_validator.validate_v3_spec(yobject)
         print("validating complete")
 
@@ -200,9 +200,24 @@ class Bundler(object):
             "type": "object",
             "required": ["choice"],
             "properties": {
-                "choice": {"description": "The type of checksum", "type": "string", "enum": ["generated", "custom"], "default": "generated"},
-                "generated": {"description": "A system generated checksum value", "type": "string", "enum": ["good", "bad"], "default": "good"},
-                "custom": {"description": "A custom checksum value", "type": "integer", "minimum": 0, "maximum": 2 ** int(xpattern.get("length", 8)) - 1},
+                "choice": {
+                    "description": "The type of checksum",
+                    "type": "string",
+                    "enum": ["generated", "custom"],
+                    "default": "generated",
+                },
+                "generated": {
+                    "description": "A system generated checksum value",
+                    "type": "string",
+                    "enum": ["good", "bad"],
+                    "default": "good",
+                },
+                "custom": {
+                    "description": "A custom checksum value",
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 2 ** int(xpattern.get("length", 8)) - 1,
+                },
             },
         }
         self._content["components"]["schemas"][schema_name] = schema
@@ -250,8 +265,12 @@ class Bundler(object):
             }
             if "features" in xpattern and "count" in xpattern["features"]:
                 counter_schema["properties"]["count"] = {"type": "integer", "default": 1}
-            self._apply_common_x_field_pattern_properties(counter_schema["properties"]["start"], xpattern, format, property_name="start")
-            self._apply_common_x_field_pattern_properties(counter_schema["properties"]["step"], xpattern, format, property_name="step")
+            self._apply_common_x_field_pattern_properties(
+                counter_schema["properties"]["start"], xpattern, format, property_name="start"
+            )
+            self._apply_common_x_field_pattern_properties(
+                counter_schema["properties"]["step"], xpattern, format, property_name="step"
+            )
             if xconstants is not None:
                 counter_schema["x-constants"] = copy.deepcopy(xconstants)
             self._content["components"]["schemas"][counter_pattern_name] = counter_schema

--- a/openapiart/tests/common/common.yaml
+++ b/openapiart/tests/common/common.yaml
@@ -41,7 +41,7 @@ components:
 
   responses:
     Success:
-      '200':
+      200:
         description: 'Standard success binary payload'
         content:
           application/octet-stream:


### PR DESCRIPTION
### Issue
The bundler uses openapi_spec_validator.validate_v3_spec to validate an openapi yaml schema. 
Currently it validates the yaml output of the openapiart but it doesn't take into account keys that are not strings such as response codes.
Downstream plugins also expect keys to be in string format.

### Fix
During yaml serialization force all dict keys to strings.

### Validation
Changed common.yaml 200 response code to a key with no quotes.