### PR TITLE
Generate string placeholders for responses with no payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import openapiart
 # bundle api files
 # validate the bundled file
 # generate the documentation file
-art = openapiart.OpenapiArt(
+art = openapiart.OpenApiArt(
     api_files=[
         "./openapiart/tests/api/info.yaml",
         "./openapiart/tests/common/common.yaml",

--- a/openapiart/openapiartprotobuf.py
+++ b/openapiart/openapiartprotobuf.py
@@ -91,10 +91,10 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
                         response_field.type = self._get_message_name(schema["type"]).replace(".", "")
                         if "format" in schema and schema["format"] == "binary":
                             response_field.type = "bytes"
-                    elif response_field.type is None:
-                        response_field.type = "string"
-                    else:
+                    elif len(schema) > 0:
                         response_field.type = self._get_message_name(schema).replace(".", "")
+                    else:
+                        response_field.type = "string"
                     response_fields.append(response_field)
             self._write("message {} {{".format(operation.response))
             id = 1

--- a/openapiart/openapiartprotobuf.py
+++ b/openapiart/openapiartprotobuf.py
@@ -67,6 +67,7 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
                 response_fields = []
                 for code, code_schema in response.value.items():
                     response_field = lambda: None
+                    response_field.type = None
                     response_field.name = "status_code_{}".format(code)
                     schema = self._get_parser("$..schema").find(code_schema)  # finds the first instance of schema in responses
                     if len(schema) > 0:
@@ -75,7 +76,7 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
                         schema_ref = self._get_parser("$..'$ref'").find(code_schema)  # gets a ref
                     if len(schema_ref) > 0:
                         schema = schema_ref[0].value
-                    else:
+                    elif len(schema) > 0:
                         schema = schema[0].value
                     if "#/components/responses" in schema:
                         # lookup the response object and use the schema or ref in that object
@@ -90,6 +91,8 @@ class OpenApiArtProtobuf(OpenApiArtPlugin):
                         response_field.type = self._get_message_name(schema["type"]).replace(".", "")
                         if "format" in schema and schema["format"] == "binary":
                             response_field.type = "bytes"
+                    elif response_field.type is None:
+                        response_field.type = "string"
                     else:
                         response_field.type = self._get_message_name(schema).replace(".", "")
                     response_fields.append(response_field)

--- a/openapiart/tests/api/api.yaml
+++ b/openapiart/tests/api/api.yaml
@@ -76,3 +76,11 @@ paths:
       responses:
         '200':
           $ref: '../common/common.yaml#/components/responses/Warnings'
+    delete:
+      tags: ['Metrics']
+      operationId: clear_warnings
+      description: >-
+        Clears warnings.
+      responses:
+        '200':
+          description: 'OK'

--- a/pkg/serdes_test.go
+++ b/pkg/serdes_test.go
@@ -13,7 +13,7 @@ import (
 func NewFullyPopulatedPrefixConfig(api openapiart.OpenapiartApi) openapiart.PrefixConfig {
 	config := api.NewPrefixConfig()
 	config.SetA("asdf").SetB(12.2).SetC(1).SetH(true).SetI([]byte{1, 0, 0, 1, 0, 0, 1, 1})
-	config.RequiredObject().SetEA(0.0)
+	config.RequiredObject().SetEA(1).SetEB(2)
 	config.SetIeee8021Qbb(true)
 	config.SetFullDuplex100Mb(2)
 	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
@@ -146,7 +146,7 @@ func TestValidJsonDecode(t *testing.T) {
 	// Valid FromJson
 	api := openapiart.NewApi()
 	c1 := api.NewPrefixConfig()
-	input_str := `{"a":"ixia", "b" : 8.8, "c" : 1, "response" : "status_200", "required_object" : {}}`
+	input_str := `{"a":"ixia", "b" : 8.8, "c" : 1, "response" : "status_200", "required_object" : {"e_a": 1, "e_b": 2}}`
 	err := c1.FromJson(input_str)
 	assert.Nil(t, err)
 }
@@ -155,7 +155,7 @@ func TestBadKeyJsonDecode(t *testing.T) {
 	// Valid Wrong key
 	api := openapiart.NewApi()
 	c1 := api.NewPrefixConfig()
-	input_str := `{"a":"ixia", "bz" : 8.8, "c" : 1, "response" : "status_200", "required_object" : {}}`
+	input_str := `{"a":"ixia", "bz" : 8.8, "c" : 1, "response" : "status_200", "required_object" : {"e_a": 1, "e_b": 2}}`
 	err := c1.FromJson(input_str)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), `unknown field "bz"`)
@@ -165,7 +165,7 @@ func TestBadDatatypeJsonDecode(t *testing.T) {
 	// Valid Wrong data type. configure "b" with string
 	api := openapiart.NewApi()
 	c1 := api.NewPrefixConfig()
-	input_str := `{"a":"ixia", "b" : "abc", "c" : 1, "response" : "status_200", "required_object" : {}}`
+	input_str := `{"a":"ixia", "b" : "abc", "c" : 1, "response" : "status_200", "required_object" : {"e_a": 1, "e_b": 2}}`
 	err := c1.FromJson(input_str)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), `invalid value for float type: "abc"`)
@@ -175,7 +175,7 @@ func TestBadDatastructureJsonDecode(t *testing.T) {
 	// Valid Wrong data structure. configure "a" with array
 	api := openapiart.NewApi()
 	c1 := api.NewPrefixConfig()
-	input_str := `{"a":["ixia"], "b" : 9.9, "c" : 1, "response" : "status_200", "required_object" : {}}`
+	input_str := `{"a":["ixia"], "b" : 9.9, "c" : 1, "response" : "status_200", "required_object" : {"e_a": 1, "e_b": 2}}`
 	err := c1.FromJson(input_str)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), `invalid value for string type: [`)
@@ -185,7 +185,7 @@ func TestWithoutValueJsonDecode(t *testing.T) {
 	// Valid without value
 	api := openapiart.NewApi()
 	c1 := api.NewPrefixConfig()
-	input_str := `{"a": "ixia", "b" : 8.8, "c" : "", "response" : "status_200", "required_object" : {}}`
+	input_str := `{"a": "ixia", "b" : 8.8, "c" : "", "response" : "status_200", "required_object" : {"e_a": 1, "e_b": 2}}`
 	err := c1.FromJson(input_str)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), `invalid value for int32 type:`)
@@ -198,7 +198,9 @@ func TestValidYamlDecode(t *testing.T) {
 b: 12.2
 c: 2
 h: true
-required_object: {}
+required_object:
+  e_a: 1
+  e_b: 2
 response: status_200
 `
 	err := config.FromYaml(data)
@@ -214,7 +216,9 @@ func TestBadKeyYamlDecode(t *testing.T) {
 bz: 12.2
 c: 2
 response: status_200
-required_object : {}
+required_object:
+  e_a: 1
+  e_b: 2
 `
 	err := config.FromYaml(data)
 	assert.NotNil(t, err)
@@ -229,7 +233,9 @@ func TestBadDatatypeYamlDecode(t *testing.T) {
 b: abc
 c: 2
 response: status_200
-required_object : {}
+required_object:
+  e_a: 1
+  e_b: 2
 `
 	err := config.FromYaml(data)
 	assert.NotNil(t, err)
@@ -244,7 +250,9 @@ func TestBadDatastructureYamlDecode(t *testing.T) {
 b: 9.9
 c: 2
 response: status_200
-required_object : {}
+required_object:
+  e_a: 1
+  e_b: 2
 `
 	err := config.FromYaml(data)
 	assert.NotNil(t, err)


### PR DESCRIPTION
### Issue
The following response that has no schema (no return payload) fails proto and go generation
```yaml
      responses:
        '200':
          description: |-
            OK
```

### Fix
Generate a placeholder string for response status codes that have no schema

### Validation
Added an api that has a response with only a status code and no schema
