### PR TITLE
License object validation and default

### DIFF
--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -86,6 +86,7 @@ class Bundler(object):
         self._resolve_x_constraint()
         self._resolve_x_status()
         self._remove_x_include()
+        self._resolve_license()
         self._resolve_strings(self._content)
         with open(self._output_filename, "w") as fp:
             yaml.dump(self._content, fp, indent=2, allow_unicode=True, line_break="\n", sort_keys=False)
@@ -418,6 +419,15 @@ class Bundler(object):
             elif key == "description":
                 descr = copy.deepcopy(value)
                 content[key] = Bundler.description(descr)
+
+    def _resolve_license(self):
+        """License object is not required by the OpenAPI spec.
+        If the license object is provided then name is a required property.
+        """
+        if "license" not in self._content["info"]:
+            self._content["info"]["license"] = {"name": "NO-LICENSE-PRESENT"}
+        elif "name" not in self._content["info"]["license"]:
+            raise Exception("The following properties are REQUIRED: license.name")
 
 
 if __name__ == "__main__":

--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -90,15 +90,27 @@ class Generator(object):
 
     def generate(self):
         self._api_filename = os.path.join(self._output_dir, self._output_file + ".py")
+        with open(self._api_filename, "w") as self._fid:
+            self._fid.write(
+                "# {} {}\n".format(
+                    self._openapi["info"]["title"],
+                    self._openapi_version,
+                )
+            )
+            self._fid.write(
+                "# License: {}\n".format(self._openapi["info"]["license"]["name"]),
+            )
+            self._fid.write("\n")
         with open(os.path.join(os.path.dirname(__file__), "common.py"), "r") as fp:
             common_content = fp.read()
             if re.search(r"def[\s+]api\(", common_content) is not None:
                 self._generated_top_level_factories.append("api")
             if self._extension_prefix is not None:
                 common_content = common_content.replace(
-                    r'"{}_{}".format(__name__, ext)', r'"' + self._extension_prefix + r"_{}." + self._package_name + r'_api".format(ext)'
+                    r'"{}_{}".format(__name__, ext)',
+                    r'"' + self._extension_prefix + r"_{}." + self._package_name + r'_api".format(ext)',
                 )
-        with open(self._api_filename, "w") as self._fid:
+        with open(self._api_filename, "a") as self._fid:
             self._fid.write(common_content)
         methods, factories = self._get_methods_and_factories()
         self._write_api_class(methods, factories)
@@ -235,7 +247,9 @@ class Generator(object):
                 self._write(3, '"%s",' % method["http_method"])
                 self._write(3, '"%s",' % method["url"])
                 self._write(3, "payload=%s," % (method["args"][1] if len(method["args"]) > 1 else "None"))
-                self._write(3, "return_object=%s," % ("self." + method["response_type"] + "()" if method["response_type"] else "None"))
+                self._write(
+                    3, "return_object=%s," % ("self." + method["response_type"] + "()" if method["response_type"] else "None")
+                )
                 self._write(2, ")")
 
     def _write_api_class(self, methods, factories):
@@ -710,7 +724,15 @@ class Generator(object):
         # return doc_string
 
     def _get_data_types(self, yproperty):
-        data_type_map = {"integer": "int", "string": "str", "boolean": "bool", "array": "list", "number": "float", "float": "float", "double": "float"}
+        data_type_map = {
+            "integer": "int",
+            "string": "str",
+            "boolean": "bool",
+            "array": "list",
+            "number": "float",
+            "float": "float",
+            "double": "float",
+        }
         if yproperty["type"] in data_type_map:
             return data_type_map[yproperty["type"]]
         else:
@@ -728,17 +750,17 @@ class Generator(object):
                     pt.update({"enum": yproperty["enum"]}) if "enum" in yproperty else None
                     pt.update({"format": "'%s'" % yproperty["format"]}) if "format" in yproperty else None
                 if len(ref) > 0:
-                    object_name = ref[0].value.split('/')[-1]
-                    class_name = object_name.replace('.', '')
-                    if 'type' in yproperty and yproperty['type'] == 'array':
-                        class_name += 'Iter'
-                    pt.update({'type': "\'%s\'" % class_name})
-                if len(ref) == 0 and 'items' in yproperty and 'type' in yproperty['items']:
-                    pt.update({'itemtype': self._get_data_types(yproperty['items'])})
-                if len(ref) == 0 and 'minimum' in yproperty:
-                    pt.update({"minimum": yproperty['minimum']})
-                if len(ref) == 0 and 'maximum' in yproperty:
-                    pt.update({"maximum": yproperty['maximum']})
+                    object_name = ref[0].value.split("/")[-1]
+                    class_name = object_name.replace(".", "")
+                    if "type" in yproperty and yproperty["type"] == "array":
+                        class_name += "Iter"
+                    pt.update({"type": "'%s'" % class_name})
+                if len(ref) == 0 and "items" in yproperty and "type" in yproperty["items"]:
+                    pt.update({"itemtype": self._get_data_types(yproperty["items"])})
+                if len(ref) == 0 and "minimum" in yproperty:
+                    pt.update({"minimum": yproperty["minimum"]})
+                if len(ref) == 0 and "maximum" in yproperty:
+                    pt.update({"maximum": yproperty["maximum"]})
                 if len(pt) > 0:
                     types.append((name, pt))
 

--- a/openapiart/openapiart.py
+++ b/openapiart/openapiart.py
@@ -43,17 +43,14 @@ class OpenApiArt(object):
         self._document()
 
     def _get_license(self):
-        try:
-            license_name = self._bundler._content["info"]["license"]["name"]
-            self._license = "License: {}".format(license_name)
-        except:
-            self._license = "NO-LICENSE-PRESENT"
+        license_name = self._bundler._content["info"]["license"]["name"]
+        self._license = "License: {}".format(license_name)
 
     def _get_info(self):
         try:
             self._info = "{} {}".format(self._bundler._content["info"]["title"], self._bundler._content["info"]["version"])
         except Exception as e:
-            ex = Exception("The following object and properties are REQUIRED: info, info.title, info.version. [{}]".format(e))
+            ex = Exception("The following object and properties are REQUIRED: info, info.title, info.version [{}]".format(e))
             raise ex
 
     def _bundle(self):

--- a/openapiart/openapiart.py
+++ b/openapiart/openapiart.py
@@ -38,8 +38,8 @@ class OpenApiArt(object):
         shutil.rmtree(self._output_dir, ignore_errors=True)
         self._api_files = api_files
         self._bundle()
-        self._get_license()
         self._get_info()
+        self._get_license()
         self._document()
 
     def _get_license(self):
@@ -47,13 +47,14 @@ class OpenApiArt(object):
             license_name = self._bundler._content["info"]["license"]["name"]
             self._license = "License: {}".format(license_name)
         except:
-            raise Exception("The /info/license/name is a REQUIRED property and must be present in the schema.")
+            self._license = "NO-LICENSE-PRESENT"
 
     def _get_info(self):
         try:
             self._info = "{} {}".format(self._bundler._content["info"]["title"], self._bundler._content["info"]["version"])
         except Exception as e:
-            self._info = "OpenAPI info error [{}]".format(e)
+            ex = Exception("The following object and properties are REQUIRED: info, info.title, info.version. [{}]".format(e))
+            raise ex
 
     def _bundle(self):
         # bundle the yaml files

--- a/openapiart/tests/api/info.yaml
+++ b/openapiart/tests/api/info.yaml
@@ -10,12 +10,6 @@ info:
       Any feedback such as bugs/enhancements/questions regarding OpenApiArt is 
       welcomed by using the contact url.      
     url: https://github.com/open-traffic-generator/openapiart/issues
-  license:
-    x-info: |-
-      The license url will be used by OpenApiArt to add that content into 
-      generated artifacts.
-    name: MIT
-    url: https://raw.githubusercontent.com/open-traffic-generator/openapiart/main/LICENSE
 
 servers: 
   - url: /

--- a/openapiart/tests/conftest.py
+++ b/openapiart/tests/conftest.py
@@ -6,6 +6,8 @@ import logging
 from .utils import common as utl
 from .server import OpenApiServer
 from .grpcserver import grpc_server
+from .server import app
+
 
 # TBD: fix this hardcoding
 # artifacts should not be generated from here as these tests are run as sudo
@@ -23,7 +25,19 @@ pytest.grpc_server = grpc_server(pytest.pb2_module, pytest.pb2_grpc_module).star
 def api():
     """Return an instance of the top level Api class from the generated package"""
     module = importlib.import_module(pytest.module_name)
-    return module.api(location="http://127.0.0.1:80", verify=False, logger=None, loglevel=logging.DEBUG)
+    return module.api(
+        location="http://127.0.0.1:{}".format(app.PORT),
+        verify=False,
+        logger=None,
+        loglevel=logging.DEBUG,
+    )
+
+
+@pytest.fixture(scope="session")
+def proto_file_name():
+    art_dir = os.path.join(os.path.dirname(__file__), "..", "..", "art")
+    proto_file = os.path.join(art_dir, "{}.proto".format(pytest.module_name))
+    return proto_file
 
 
 @pytest.fixture

--- a/openapiart/tests/server.py
+++ b/openapiart/tests/server.py
@@ -12,6 +12,7 @@ import pytest
 app = Flask(__name__)
 app.CONFIG = None
 app.PACKAGE = None
+app.PORT = 18080
 
 
 @app.route("/config", methods=["POST"])
@@ -20,7 +21,9 @@ def set_config():
     config.deserialize(request.data.decode("utf-8"))
     test = config.h
     if test is not None and isinstance(test, bool) is False:
-        return Response(status=590, response=json.dumps({"detail": "invalid data type"}), headers={"Content-Type": "application/json"})
+        return Response(
+            status=590, response=json.dumps({"detail": "invalid data type"}), headers={"Content-Type": "application/json"}
+        )
     else:
         app.CONFIG = config
         return Response(status=200)
@@ -39,7 +42,7 @@ def after_request(resp):
 
 
 def web_server():
-    app.run(port=80, debug=True, use_reloader=False)
+    app.run(port=app.PORT, debug=True, use_reloader=False)
 
 
 class OpenApiServer(object):
@@ -59,7 +62,7 @@ class OpenApiServer(object):
         return self
 
     def _wait_until_ready(self):
-        api = app.PACKAGE.api(location="http://127.0.0.1:80")
+        api = app.PACKAGE.api(location="http://127.0.0.1:{}".format(app.PORT))
         while True:
             try:
                 api.get_config()

--- a/openapiart/tests/test_license.py
+++ b/openapiart/tests/test_license.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def test_license(proto_file_name):
+    """Verify the license is set to NO-LICENSE-PRESENT"""
+    with open(proto_file_name) as fp:
+        contents = fp.read()
+
+    assert "NO-LICENSE-PRESENT" in contents
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", "-s", __file__])


### PR DESCRIPTION
### Issue
Per the openapi spec the license object is not required but the generator currently raises an exception stating the license is required.  

### Fixes
If the license object is not present, default the license.name to "NO-LICENSE-PRESENT" and do not raise an exception.
Add missing version and license information to generated python ux sdk file.
Move mock http server port to higher port number to allow running in linux dev env.

### Validation
Removed the license object from the info.yaml and added a unit test to confirm presence of "NO-LICENSE-PRESENT" license info in generated code.
