### PR TITLE
Fix go ux sdk SetMsg method

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -650,7 +650,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
             }}
 
             func (obj *{struct}) SetMsg(msg *{pb_pkg_name}.{interface}) {interface} {{
-                obj.obj = msg
+                proto.Merge(obj.obj, msg)
                 return obj
             }}
 

--- a/pkg/serdes_test.go
+++ b/pkg/serdes_test.go
@@ -258,3 +258,21 @@ required_object:
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), `invalid value for string type: [`)
 }
+
+func TestSetMsg(t *testing.T) {
+	api := openapiart.NewApi()
+	config := NewFullyPopulatedPrefixConfig(api)
+	copy := openapiart.NewApi().NewPrefixConfig()
+	copy.SetMsg(config.Msg())
+	assert.Equal(t, config.ToYaml(), copy.ToYaml())
+}
+
+func TestNestedSetMsg(t *testing.T) {
+	api := openapiart.NewApi()
+	eObject := openapiart.NewApi().NewPrefixConfig().K().EObject()
+	eObject.SetEA(23423.22)
+	eObject.SetName("asdfasdf")
+	config := api.NewPrefixConfig()
+	config.K().EObject().SetMsg(eObject.Msg())
+	assert.Equal(t, config.K().EObject().ToYaml(), eObject.ToYaml())
+}


### PR DESCRIPTION
### Issue
The generated go ux sdk SetMsg was not correctly copying the input message.

### Fix
Instead of assigning the pointer SetMsg now uses the proto.Merge method.

### Validation
Added TestSetMsg and TestNestedSetMsg unit tests.