### PR TITLE
Fix setter to create a copy

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -994,7 +994,9 @@ class OpenApiArtGo(OpenApiArtPlugin):
             )
             return
         elif field.struct is not None:
-            body = """obj.obj.{fieldname} = value.Msg()""".format(fieldname=field.name)
+            body = """obj.{fieldname}().SetMsg(value.Msg())""".format(
+                fieldname=self._get_external_struct_name(field.name),
+            )
         elif field.isPointer:
             body = """obj.obj.{fieldname} = &value""".format(fieldname=field.name)
         else:


### PR DESCRIPTION
### Issue
The object setter function was incorrectly using pointer assignment as opposed to using SetMsg() and Msg().

### Fix
Use SetMsg() and Msg()

### Validation
go linter does not complain of protobuf mutex pointer copy