### PR TITLE
Meaningful error should be thrown if a component contains a nested component

### DIFF
--- a/openapiart/tests/config/negative_nested_config.yaml
+++ b/openapiart/tests/config/negative_nested_config.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+
+info:
+  title: yaml definition used for testing validation
+  description: A Sample Service in Go.
+  version: 0.0.0
+
+servers:
+- url: https://0.0.0.0
+
+paths:
+  /:
+    get:
+      tags: [AnythingGoes]
+      operationId: getTest
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RootComponentWithNested'
+
+components:
+  schemas:
+    RootComponentWithNested:
+      description: |-
+        Nested Component is not supported and should throw a meaningful exception
+        Only root level components are checked for nested
+      properties:
+        name:
+          type: string
+        nested_component_1:
+          type: object
+          properties:
+            name:
+              type: string
+        nested_component_2:
+          type: object
+          properties:
+            name:
+              type: string

--- a/openapiart/tests/test_validation.py
+++ b/openapiart/tests/test_validation.py
@@ -1,0 +1,24 @@
+import os
+import pytest
+import openapiart
+
+def test_validation():
+    rootfolder = os.path.dirname(__file__)
+    outputfolder = os.path.join(rootfolder, 'unittest-tmp')
+
+    try:
+        openapiart.OpenApiArt(
+            api_files=[
+                os.path.join(rootfolder, 'config/negative_nested_config.yaml')
+            ],
+            artifact_dir=outputfolder,
+            protobuf_name="unittest-tmp"
+        )
+        assert False
+    except Exception as error:
+        message = str(error)
+        assert message.find("nested_component_1") > 0
+        assert message.find("nested_component_2") > 0
+
+if __name__ == "__main__":
+    pytest.main(["-v", "-s", __file__])


### PR DESCRIPTION
### Issue
Issue #201

### Fix
Add validation for nested components

### Validation
added unit test `test_validation.py`