### PR TITLE
Fix go ux sdk fieldname generation

### DIFF
--- a/openapiart/tests/api/api.yaml
+++ b/openapiart/tests/api/api.yaml
@@ -15,6 +15,7 @@ paths:
         x-include:
         - '../common/common.yaml#/components/responses/Success'
         - '../common/common.yaml#/components/responses/Error.400'
+        - '../common/common.yaml#/components/responses/Error.404'
         - '../common/common.yaml#/components/responses/Error500'
 
     patch:

--- a/openapiart/tests/common/common.yaml
+++ b/openapiart/tests/common/common.yaml
@@ -61,6 +61,13 @@ components:
           application/json:
             schema:
               $ref: '#/components/schemas/Error.Details'
+    Error.404:
+      '404':
+        description: 'error 404'
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Error.Details'
     Error500:
       '500':
         description: 'error 5xx'


### PR DESCRIPTION
### Issue
Field name containing a number preceded with a 0 fails go ux sdk generation with a go generated artifact that doesn't compile.

### Fix
Changed the fieldname generation to match protobuf fieldname generation

### Validation
Reproduced using an error code 404 to the common.yaml. With the fix the code generation generates a go ux sdk artifact that compiles.