### PR TITLE
Add prefer binary flag

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--prefer-binary
 pytest
 pyyaml
 jsonpath-ng


### PR DESCRIPTION
### Issue
#227 

### Fix
add --prefer-binary flag to pip install 

### Validation
manually inspect workflow for 2.7 to ensure binaries are not being built if not required