### PR TITLE
internal wrapper list for gosnappi helper Items()

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -1183,12 +1183,6 @@ class OpenApiArtGo(OpenApiArtPlugin):
             }}
 
             func (obj *{internal_struct}) Items() {field_type} {{
-                if len(obj.obj.{internal_items_name}) != len(obj.obj.obj.{field_name}) {{
-                    obj.obj.{internal_items_name} = {field_type}{{}}
-                    for _, item := range obj.obj.obj.{field_name} {{
-                        obj.obj.{internal_items_name} = append(obj.obj.{internal_items_name}, &{field_internal_struct}{{obj: item}})
-                    }}
-                }}
                 return obj.obj.{internal_items_name}
             }}
 
@@ -1457,12 +1451,21 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 if field.struct and field.isEnum is False:
                     statements.append(
                         """if obj.obj.{name} != nil {{
+                            if set_default {{
+                                obj.{internal_items_name} = {field_type}{{}}
+                                for _, item := range obj.obj.{name} {{
+                                    obj.{internal_items_name} = append(obj.{internal_items_name}, &{field_internal_struct}{{obj: item}})
+                                }}
+                            }}
                             for _, item := range obj.{name}().Items() {{
                                 item.validateObj(set_default)
                             }}
                         }}
                         """.format(
-                            name=field.name
+                            name=field.name,
+                            field_type=field.type,
+                            internal_items_name="{}s".format(field.struct),
+                            field_internal_struct=field.struct
                         )
                     )
                     valid += 1

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -101,6 +101,9 @@ class FluentField(object):
         self.hasminmax = False
         self.min = None
         self.max = None
+        self.hasminmaxlength = False
+        self.min_length = None
+        self.max_length = None
 
 
 class OpenApiArtGo(OpenApiArtPlugin):
@@ -880,7 +883,6 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 interfaces.append("// {}".format(field.has_method_description))
                 interfaces.append(field.has_method)
         interface_signatures = "\n".join(interfaces)
-        intf = "\n//\t(*{}).".format(new.interface)
         self._write(
             """
             {description}
@@ -908,7 +910,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
     def _write_field_getter(self, new, field):
         if field.getter_method is None:
             return
-        elif field.isArray and field.isEnum is False:
+        if field.isArray and field.isEnum is False:
             if field.struct:
                 body = """if obj.obj.{name} == nil {{
                         obj.obj.{name} = []*{pb_pkg_name}.{pb_struct}{{}}
@@ -921,31 +923,55 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     parent=new.struct,
                 )
             else:
+                block = "obj.obj.{name} = make({type}, 0)".format(
+                    name=field.name, type=field.type
+                )
+                if field.setChoiceValue is not None:
+                    if field.default is not None and field.default != "":
+                        if field.type == "[]string":
+                            value = '"{}"'.format('", "'.join(field.default))
+                        else:
+                            value = ",".join([str(i) for i in field.default])
+                        block = """obj.Set{name}({type}{{{default}}})""".format(
+                            name=field.name,
+                            type=field.type,
+                            default=value
+                        )
+                    else:
+                        block = """
+                            obj.SetChoice({interface}Choice.{enum})
+                            obj.obj.{name} = make({type}, 0)
+                        """.format(
+                            interface=new.interface,
+                            enum=field.setChoiceValue,
+                            name=field.name,
+                            type=field.type,
+                        )
                 body = """if obj.obj.{name} == nil {{
-                        obj.obj.{name} = make({type}, 0)
+                        {block}
                     }}
                     return obj.obj.{name}""".format(
                     name=field.name,
-                    type=field.type,
+                    block=block
                 )
         elif field.struct is not None:
             # at this time proto generation ignores the optional keyword
             # if the type is an object
-            body = ""
+            set_enum_choice = None
             if field.setChoiceValue is not None:
-                body = """obj.SetChoice({interface}Choice.{enum})
-                """.format(
+                set_enum_choice = """obj.SetChoice({interface}Choice.{enum})""".format(
                     interface=new.interface,
                     enum=field.setChoiceValue,
                 )
-            body += """if obj.obj.{name} == nil {{
+            body = """if obj.obj.{name} == nil {{
+                    {set_enum_choice}
                     obj.obj.{name} = New{pb_struct}().Msg()
                 }}
                 return &{struct}{{obj: obj.obj.{name}}}""".format(
                 name=field.name,
-                pb_pkg_name=self._protobuf_package_name,
                 pb_struct=field.external_struct,
                 struct=field.struct,
+                set_enum_choice=set_enum_choice if set_enum_choice else ""
             )
         elif field.isEnum:
             enum_types = []
@@ -1010,32 +1036,57 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 )
             return
         elif field.isPointer:
-            default = ""
-            if field.default is not None and field.isOptional:
-                default = """
+            set_enum_choice = None
+            default = None
+            if field.setChoiceValue is not None:
+                if field.default is not None:
+                    if field.type == "string":
+                        value = '"{}"'.format(field.default)
+                    elif field.type in ["int32", "int64", "float32", "float64"]:
+                        value = "{fieldtype}({value})".format(fieldtype=field.type, value=field.default)
+                    else:
+                        value = field.default
+                    default = """value := {value}
+                            obj.obj.{fieldname} = &value""".format(value=value, fieldname=field.name)
+                set_enum_choice = """
                     if obj.obj.{fieldname} == nil {{
-                        *obj.obj.{fieldname} = {value}
+                        obj.SetChoice({interface}Choice.{enum})
+                        {default}
                     }}
                 """.format(
-                    fieldname=field.name, value='"{}"'.format(field.default) if "string" in field.type else field.default
+                    fieldname=field.name,
+                    default=default if default else "",
+                    interface=new.interface, enum=field.setChoiceValue
                 )
-            body = """{default}
+            body = """{set_enum_choice}
                 return *obj.obj.{fieldname}
                 """.format(
-                fieldname=field.name, default=default
+                fieldname=field.name,
+                set_enum_choice=set_enum_choice if set_enum_choice is not None else ""
             )
         else:
-            default = ""
-            # if field.default is not None and field.isOptional:
-            #     default = """
-            #         if obj.obj.{fieldname} == {check} {{
-            #             obj.obj.{fieldname} = {value}
-            #         }}
-            #     """.format(
-            #         fieldname=field.name, value="\"{}\"".format(field.default) if "string" in field.type else field.default,
-            #         check="\"\"" if "string" in field.type else 0
-            #     )
-            body = """{default}\n return obj.obj.{fieldname}""".format(fieldname=field.name, default=default)
+            set_enum_choice = None
+            default = None
+            if field.setChoiceValue is not None:
+                if field.default is not None:
+                    default = "obj.obj.{fieldname} = {value}".format(
+                        value='"{}"'.format(field.default) if "string" in field.type else field.default,
+                        fieldname=field.name
+                    )
+                set_enum_choice = """
+                    if obj.obj.{fieldname} == nil {{
+                        obj.SetChoice({interface}Choice.{enum})
+                        {default}
+                    }}
+                """.format(
+                    fieldname=field.name,
+                    interface=new.interface, enum=field.setChoiceValue,
+                    default=default if default else ""
+                )
+            body = """{set_enum_choice}\n return obj.obj.{fieldname}""".format(
+                fieldname=field.name,
+                set_enum_choice=set_enum_choice if set_enum_choice is not None else ""
+            )
         self._write(
             """
             // {fieldname} returns a {fieldtype}\n{description}
@@ -1091,16 +1142,20 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     interface=new.interface,
                     fieldname=field.name,
                 )
-            enum_set = [
-                """
-                if string(value) != "{name}" {{
-                    obj.obj.{external_name} = nil
-                }}
-            """.format(
-                    name=name, external_name=self._get_external_field_name(name)
-                )
-                for name in field.enums
-            ]
+            enum_set = [self._get_external_field_name(name) for name in field.enums]
+            enum_body = []
+            for enum_field in new.interface_fields:
+                if enum_field.name not in enum_set:
+                    continue
+                if enum_field.isEnum:
+                    enum_body.append(
+                        "obj.obj.{name} = {pb_pkg_name}.{interface}_{name}_unspecified.Enum()".format(
+                            name=enum_field.name, pb_pkg_name=self._protobuf_package_name,
+                            interface=new.interface, fieldname=enum_field.name
+                        )
+                    )
+                    continue
+                enum_body.append("obj.obj.{name} = nil".format(name=enum_field.name))
             self._write(
                 """func (obj* {struct}) Set{fieldname}(value {interface}{fieldname}Enum) {interface} {{
                 intValue, ok := {pb_pkg_name}.{interface}_{fieldname}_Enum_value[string(value)]
@@ -1119,7 +1174,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     struct=new.struct,
                     fieldname=field.name,
                     body=body,
-                    enum_set="\n".join(enum_set) if field.name == "Choice" else "",
+                    enum_set="\n".join(enum_body) if field.name == "Choice" else "",
                 )
             )
             return
@@ -1141,8 +1196,8 @@ class OpenApiArtGo(OpenApiArtPlugin):
             """
             // Set{fieldname} sets the {fieldtype} value in the {fieldstruct} object\n{description}
             func (obj *{newstruct}) {setter_method} {{
-                {body}
                 {set_choice}
+                {body}
                 return obj
             }}
             """.format(
@@ -1178,8 +1233,9 @@ class OpenApiArtGo(OpenApiArtPlugin):
             type {interface} interface {{
                 Items() {field_type}
                 Add() {field_external_struct}
-                Append(newObj {field_external_struct}) {interface}
+                Append(items ...{field_external_struct}) {interface}
                 Set(index int, newObj {field_external_struct}) {interface}
+                Clear() {interface}
             }}
 
             func (obj *{internal_struct}) Items() {field_type} {{
@@ -1195,15 +1251,25 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 return newLibObj
             }}
 
-            func (obj *{internal_struct}) Append(newObj {field_external_struct}) {interface} {{
-                obj.obj.obj.{field_name} = append(obj.obj.obj.{field_name}, newObj.Msg())
-                obj.obj.{internal_items_name} = append(obj.obj.{internal_items_name}, newObj)
+            func (obj *{internal_struct}) Append(items ...{field_external_struct}) {interface} {{
+                for _, item := range items {{
+                    newObj := item.Msg()
+                    obj.obj.obj.{field_name} = append(obj.obj.obj.{field_name}, newObj)
+                    obj.obj.{internal_items_name} = append(obj.obj.{internal_items_name}, item)
+                }}
                 return obj
             }}
 
             func (obj *{internal_struct}) Set(index int, newObj {field_external_struct}) {interface} {{
                 obj.obj.obj.{field_name}[index] = newObj.Msg()
                 obj.obj.{internal_items_name}[index] = newObj
+                return obj
+            }}
+            func (obj *{internal_struct}) Clear()  {interface} {{
+                if obj.obj.obj.{field_name} != nil {{
+                    obj.obj.obj.{field_name} = nil
+                    obj.obj..{internal_items_name} = {field_type}{{}}
+                }}
                 return obj
             }}
             """.format(
@@ -1265,6 +1331,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 field.setChoiceValue = None
             field.isEnum = len(self._get_parser("$..enum").find(property_schema)) > 0
             field.hasminmax = "minimum" in property_schema or "maximum" in property_schema
+            field.hasminmaxlength = "minLength" in property_schema or "maxLength" in property_schema
             field.isArray = "type" in property_schema and property_schema["type"] == "array"
             if field.isEnum:
                 field.enums = self._get_parser("$..enum").find(property_schema)[0].value
@@ -1279,6 +1346,9 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     and "int" in field.type
                 ):
                     field.type = field.type.replace("32", "64")
+            if field.hasminmaxlength:
+                field.min_length = None if "minLength" not in property_schema else property_schema["minLength"]
+                field.max_length = None if "maxLength" not in property_schema else property_schema["maxLength"]
             if fluent_new.isRpcResponse:
                 if field.type == "[]byte":
                     field.name = "Bytes"
@@ -1621,6 +1691,46 @@ class OpenApiArtGo(OpenApiArtPlugin):
                         body=body, name=field.name
                     )
                 statements.append(body)
+            if field.hasminmaxlength and "string" in field.type:
+                valid += 1
+                line = []
+                if field.min_length is not None:
+                    line.append("len({pointer}{value}) < {min_length}")
+                if field.max_length is not None:
+                    line.append("len({pointer}{value}) > {max_length}")
+                body = (
+                    "if "
+                    + " || ".join(line)
+                    + """ {{
+                    validation = append(
+                        validation, fmt.Sprintf("{min_length} <= length of {interface}.{name} <= {max_length} but Got %d", len({pointer}{value})))
+                }}
+                """
+                ).format(
+                    name=field.name,
+                    interface=new.interface,
+                    max_length="any" if field.max_length is None else field.max_length,
+                    pointer="*" if field.isPointer else "",
+                    min_length=field.min_length if field.min_length is None else field.min_length,
+                    value="item" if field.isArray else "obj.obj.{name}".format(name=field.name),
+                )
+                if field.isArray:
+                    body = """
+                        for _, item := range obj.obj.{name} {{
+                            {body}
+                        }}
+                    """.format(
+                        body=body, name=field.name
+                    )
+                if field.isPointer:
+                    body = """
+                        if obj.obj.{name} != nil {{
+                            {body}
+                        }}
+                    """.format(
+                        body=body, name=field.name
+                    )
+                statements.append(body)
             if valid == 0:
                 print(
                     "{field} of type {ftype} and {req} is not set for validation on interface {interface}".format(
@@ -1723,6 +1833,8 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     enum_value=enum_value,
                 )
                 if field.name in hasChoiceConfig:
+                    if choice_body is not None:
+                        body1 = body1.replace(" == nil", ".Number() == 0")
                     choice_body = body1 if choice_body is None else choice_body.replace("<choice_fields>", body1)
                 else:
                     body = body + body1.replace("<choice_fields>", "")

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -1197,16 +1197,19 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 obj.obj.obj.{field_name} = append(obj.obj.obj.{field_name}, newObj)
                 newLibObj := &{field_internal_struct}{{obj: newObj}}
                 newLibObj.setDefault()
+                obj.obj.{internal_items_name} = append(obj.obj.{internal_items_name}, newLibObj)
                 return newLibObj
             }}
 
             func (obj *{internal_struct}) Append(newObj {field_external_struct}) {interface} {{
                 obj.obj.obj.{field_name} = append(obj.obj.obj.{field_name}, newObj.Msg())
+                obj.obj.{internal_items_name} = append(obj.obj.{internal_items_name}, newObj)
                 return obj
             }}
 
             func (obj *{internal_struct}) Set(index int, newObj {field_external_struct}) {interface} {{
                 obj.obj.obj.{field_name}[index] = newObj.Msg()
+                obj.obj.{internal_items_name}[index] = newObj
                 return obj
             }}
             """.format(

--- a/pkg/unit_test.go
+++ b/pkg/unit_test.go
@@ -108,24 +108,45 @@ func TestSimpleTypes(t *testing.T) {
 	assert.Equal(t, i, config.I())
 }
 
+var gaValues = []string{"1111", "2222"}
+var gbValues = []int32{11, 22}
+var gcValues = []float32{11.11, 22.22}
+
 func TestIterAdd(t *testing.T) {
 	api := openapiart.NewApi()
 	config := api.NewPrefixConfig()
-	config.G().Add()
-	config.G().Add()
+	config.G().Add().SetGA("1111").SetGB(11).SetGC(11.11)
+	config.G().Add().SetGA("2222").SetGB(22).SetGC(22.22)
+
 	assert.Equal(t, len(config.G().Items()), 2)
+	for idx, gObj := range config.G().Items() {
+		assert.Equal(t, gaValues[idx], gObj.GA())
+		assert.Equal(t, gbValues[idx], gObj.GB())
+		assert.Equal(t, gcValues[idx], gObj.GC())
+	}
 }
 
 func TestIterAppend(t *testing.T) {
 	api := openapiart.NewApi()
 	config := api.NewPrefixConfig()
-	config.G().Add()
-	g := config.G().Append(openapiart.NewGObject())
+	config.G().Add().SetGA("1111").SetGB(11).SetGC(11.11)
+	g := config.G().Append(openapiart.NewGObject().SetGA("2222").SetGB(22).SetGC(22.22))
 
 	assert.Equal(t, len(g.Items()), 2)
+	for idx, gObj := range config.G().Items() {
+		assert.Equal(t, gaValues[idx], gObj.GA())
+		assert.Equal(t, gbValues[idx], gObj.GB())
+		assert.Equal(t, gcValues[idx], gObj.GC())
+	}
 }
 
 func TestIterSet(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			errValue := "runtime error: index out of range [3] with length 2"
+			assert.Equal(t, errValue, fmt.Sprintf("%v", err))
+		}
+	}()
 	api := openapiart.NewApi()
 	config := api.NewPrefixConfig()
 	name := "new name set on slice"
@@ -134,6 +155,9 @@ func TestIterSet(t *testing.T) {
 	g := config.G().Set(1, openapiart.NewGObject().SetName(name))
 
 	assert.Equal(t, name, g.Items()[1].Name())
+	assert.Equal(t, len(g.Items()), 2)
+
+	config.G().Set(3, openapiart.NewGObject().SetName(name))
 }
 
 func TestEObject(t *testing.T) {
@@ -458,13 +482,13 @@ func TestDefaultSimpleTypes(t *testing.T) {
 	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
 	actual_result := config.ToJson()
 	expected_result := `{
-		"a":"asdf", 
-		"b" : 65, 
-		"c" : 33,  
-		"h": true, 
-		"response" : "status_200", 
+		"a":"asdf",
+		"b" : 65,
+		"c" : 33,
+		"h": true,
+		"response" : "status_200",
 		"required_object" : {
-			"e_a" : 1, 
+			"e_a" : 1,
 			"e_b" : 2
 		}
 	}`
@@ -587,12 +611,12 @@ func TestOptionalDefault(t *testing.T) {
 func TestInterger64(t *testing.T) {
 	config := openapiart.NewPrefixConfig()
 	int_64 := `{
-		"a":"asdf", 
-		"b" : 65, 
+		"a":"asdf",
+		"b" : 65,
 		"c" : 33,
-		"response" : "status_200", 
+		"response" : "status_200",
 		"required_object" : {
-			"e_a" : 1, 
+			"e_a" : 1,
 			"e_b" : 2
 		},
 		"integer64": 100
@@ -601,12 +625,12 @@ func TestInterger64(t *testing.T) {
 	fmt.Println(config.Integer64())
 	assert.Nil(t, err)
 	int_64_str := `{
-		"a":"asdf", 
-		"b" : 65, 
+		"a":"asdf",
+		"b" : 65,
 		"c" : 33,
-		"response" : "status_200", 
+		"response" : "status_200",
 		"required_object" : {
-			"e_a" : 1, 
+			"e_a" : 1,
 			"e_b" : 2
 		},
 		"integer64": "100"
@@ -626,12 +650,12 @@ func TestFromJsonToCleanObject(t *testing.T) {
 	config.SetInteger64(200645)
 	config.Validate()
 	new_json := `{
-		"a":"asdf", 
-		"b" : 65, 
+		"a":"asdf",
+		"b" : 65,
 		"c" : 33,
-		"response" : "status_200", 
+		"response" : "status_200",
 		"required_object" : {
-			"e_a" : 1, 
+			"e_a" : 1,
 			"e_b" : 2
 		},
 		"h": false
@@ -640,11 +664,11 @@ func TestFromJsonToCleanObject(t *testing.T) {
 	assert.Nil(t, err)
 	require.JSONEq(t, new_json, config.ToJson())
 	new_json1 := `{
-		"b" : 65, 
+		"b" : 65,
 		"c" : 33,
-		"response" : "status_200", 
+		"response" : "status_200",
 		"required_object" : {
-			"e_a" : 1, 
+			"e_a" : 1,
 			"e_b" : 2
 		},
 		"h": false

--- a/pkg/unit_test.go
+++ b/pkg/unit_test.go
@@ -160,6 +160,34 @@ func TestIterSet(t *testing.T) {
 	config.G().Set(3, openapiart.NewGObject().SetName(name))
 }
 
+func TestListWrapFromJson(t *testing.T) {
+	var listWrap = `{
+		"required_object":  {
+		  "e_a":  3,
+		  "e_b":  47.234
+		},
+		"response":  "status_200",
+		"a":  "asdfg",
+		"b":  12.2,
+		"c":  1,
+		"g":  [
+		  {
+			"g_a":  "1111",
+			"g_b":  11,
+			"g_c":  11.11,
+			"choice":  "g_d",
+			"g_d":  "some string",
+			"g_f":  "a"
+		  }
+		],
+		"h":  true
+	  }`
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	config.FromJson(listWrap)
+	assert.Equal(t, len(config.G().Items()), 1)
+}
+
 func TestEObject(t *testing.T) {
 	var ea float32 = 1.1
 	eb := 1.2

--- a/pkg/unit_test.go
+++ b/pkg/unit_test.go
@@ -222,6 +222,19 @@ func TestGObject(t *testing.T) {
 	}
 	log.Print(g1.ToJson(), g1.ToYaml())
 }
+func TestGObjectAppendMultiple(t *testing.T) {
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	items := []openapiart.GObject{
+		openapiart.NewGObject().SetGA("g_1"),
+		openapiart.NewGObject().SetGA("g_2"),
+		openapiart.NewGObject().SetGA("g_3"),
+	}
+	config.G().Append(items...)
+	assert.Len(t, config.G().Items(), 3)
+	item := config.G().Items()[1]
+	assert.Equal(t, item.GA(), "g_2")
+}
 
 func TestLObject(t *testing.T) {
 	var int_ int32 = 80
@@ -510,13 +523,13 @@ func TestDefaultSimpleTypes(t *testing.T) {
 	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
 	actual_result := config.ToJson()
 	expected_result := `{
-		"a":"asdf",
-		"b" : 65,
-		"c" : 33,
-		"h": true,
-		"response" : "status_200",
+		"a":"asdf", 
+		"b" : 65, 
+		"c" : 33,  
+		"h": true, 
+		"response" : "status_200", 
 		"required_object" : {
-			"e_a" : 1,
+			"e_a" : 1, 
 			"e_b" : 2
 		}
 	}`
@@ -639,12 +652,12 @@ func TestOptionalDefault(t *testing.T) {
 func TestInterger64(t *testing.T) {
 	config := openapiart.NewPrefixConfig()
 	int_64 := `{
-		"a":"asdf",
-		"b" : 65,
+		"a":"asdf", 
+		"b" : 65, 
 		"c" : 33,
-		"response" : "status_200",
+		"response" : "status_200", 
 		"required_object" : {
-			"e_a" : 1,
+			"e_a" : 1, 
 			"e_b" : 2
 		},
 		"integer64": 100
@@ -653,12 +666,12 @@ func TestInterger64(t *testing.T) {
 	fmt.Println(config.Integer64())
 	assert.Nil(t, err)
 	int_64_str := `{
-		"a":"asdf",
-		"b" : 65,
+		"a":"asdf", 
+		"b" : 65, 
 		"c" : 33,
-		"response" : "status_200",
+		"response" : "status_200", 
 		"required_object" : {
-			"e_a" : 1,
+			"e_a" : 1, 
 			"e_b" : 2
 		},
 		"integer64": "100"
@@ -678,12 +691,12 @@ func TestFromJsonToCleanObject(t *testing.T) {
 	config.SetInteger64(200645)
 	config.Validate()
 	new_json := `{
-		"a":"asdf",
-		"b" : 65,
+		"a":"asdf", 
+		"b" : 65, 
 		"c" : 33,
-		"response" : "status_200",
+		"response" : "status_200", 
 		"required_object" : {
-			"e_a" : 1,
+			"e_a" : 1, 
 			"e_b" : 2
 		},
 		"h": false
@@ -692,11 +705,11 @@ func TestFromJsonToCleanObject(t *testing.T) {
 	assert.Nil(t, err)
 	require.JSONEq(t, new_json, config.ToJson())
 	new_json1 := `{
-		"b" : 65,
+		"b" : 65, 
 		"c" : 33,
-		"response" : "status_200",
+		"response" : "status_200", 
 		"required_object" : {
-			"e_a" : 1,
+			"e_a" : 1, 
 			"e_b" : 2
 		},
 		"h": false
@@ -722,4 +735,148 @@ func TestChoiceStale(t *testing.T) {
 	}`
 	fmt.Println(fObject.ToJson())
 	require.JSONEq(t, expected_json1, fObject.ToJson())
+}
+
+func TestChoice2(t *testing.T) {
+	expected_json := `{
+		"required_object": {
+		  "e_a": 1,
+		  "e_b": 2
+		},
+		"response": "status_200",
+		"a": "asdf",
+		"b": 12.2,
+		"c": 1,
+		"e": {
+		  "e_a": 1.1,
+		  "e_b": 1.2,
+		  "m_param1": "Mparam1",
+		  "m_param2": "Mparam2"
+		},
+		"h": true,
+		"j": [
+		  {
+			"choice": "j_a",
+			"j_a": {
+			  "e_a": 1,
+			  "e_b": 2
+			}
+		  },
+		  {
+			"choice": "j_b",
+			"j_b": {
+			  "choice": "f_a",
+			  "f_a": "asf"
+			}
+		  }
+		],
+		"k": {
+		  "f_object": {
+			"choice": "f_a",
+			"f_a": "asf"
+		  }
+		}
+	  }`
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	config.SetA("asdf").SetB(12.2).SetC(1)
+	config.RequiredObject().SetEA(1).SetEB(2)
+	config.K().FObject().SetFA("asf")
+	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+	config.E().SetEA(1.1).SetEB(1.2).SetMParam1("Mparam1").SetMParam2("Mparam2")
+	config.J().Add().JA().SetEA(1.0).SetEB(2.0)
+	config.J().Add().JB().SetFA("asf")
+	log.Print(config.ToJson())
+	require.JSONEq(t, expected_json, config.ToJson())
+}
+
+func TestGetter(t *testing.T) {
+	fObject := openapiart.NewFObject()
+	fObject.FA()
+	expected_json := `{
+		"choice": "f_a",
+		"f_a": "some string"
+	}`
+	fmt.Println(fObject.ToJson())
+	require.JSONEq(t, expected_json, fObject.ToJson())
+
+	fObject1 := openapiart.NewFObject()
+	fObject1.Choice()
+	fmt.Println(fObject1.ToJson())
+	require.JSONEq(t, expected_json, fObject1.ToJson())
+
+	pattern := openapiart.NewIpv4Pattern()
+	pattern.Ipv4()
+	exp_ipv4 := `{
+		"ipv4":  {
+			"choice":  "value",
+			"value":  "0.0.0.0"
+		}
+	}`
+	fmt.Println(pattern.ToJson())
+	require.JSONEq(t, exp_ipv4, pattern.ToJson())
+	pattern.Ipv4().SetValue("10.1.1.1")
+	assert.Equal(t, "10.1.1.1", pattern.Ipv4().Value())
+	pattern.Ipv4().Values()
+	exp_ipv41 := `{
+		"ipv4": {
+			"choice": "values",
+			"values": [
+				"0.0.0.0"
+			]
+		}
+	}`
+	fmt.Println(pattern.ToJson())
+	require.JSONEq(t, exp_ipv41, pattern.ToJson())
+	pattern.Ipv4().SetValues([]string{"20.1.1.1"})
+	assert.Equal(t, []string{"20.1.1.1"}, pattern.Ipv4().Values())
+	checksum := openapiart.NewChecksumPattern().Checksum()
+	ch_json := `{
+		"choice": "generated",
+		"generated": "good"
+	}`
+	require.JSONEq(t, ch_json, checksum.ToJson())
+	fmt.Println(checksum.ToJson())
+}
+
+func TestStringLength(t *testing.T) {
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	config.SetA("asdf").SetB(12.2).SetC(1).SetH(true).SetI([]byte{1, 0, 0, 1, 0, 0, 1, 1})
+	config.RequiredObject().SetEA(1).SetEB(2)
+	config.SetIeee8021Qbb(true)
+	config.SetFullDuplex100Mb(2)
+	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+	config.SetStrLen("123456")
+	log.Print(config.ToJson())
+}
+
+func TestListClear(t *testing.T) {
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	list := config.G()
+	list.Append(openapiart.NewGObject().SetGA("a1"))
+	list.Append(openapiart.NewGObject().SetGA("a2"))
+	list.Append(openapiart.NewGObject().SetGA("a3"))
+	assert.Len(t, list.Items(), 3)
+	list.Clear()
+	assert.Len(t, list.Items(), 0)
+	list.Append(openapiart.NewGObject().SetGA("b1"))
+	list.Append(openapiart.NewGObject().SetGA("b2"))
+	assert.Len(t, list.Items(), 2)
+	assert.Equal(t, list.Items()[1].GA(), "b2")
+
+	list1 := []openapiart.GObject{
+		openapiart.NewGObject().SetGA("c_1"),
+		openapiart.NewGObject().SetGA("c_2"),
+		openapiart.NewGObject().SetGA("c_3"),
+	}
+	list.Clear().Append(list1...)
+	assert.Len(t, list.Items(), 3)
+	list2 := []openapiart.GObject{
+		openapiart.NewGObject().SetGA("d_1"),
+		openapiart.NewGObject().SetGA("d_1"),
+	}
+	list.Clear().Append(list2...)
+	assert.Len(t, list.Items(), 2)
 }


### PR DESCRIPTION
This should address https://github.com/open-traffic-generator/openapiart/issues/230

We will incorporate another internal variable within our wrapper package. We will fill that variable when access Items(). So it will not process each time. 
```go
type metricsResponse struct {
	obj          *snappipb.MetricsResponse
	portMetrics  []PortMetric
	flowMetrics  []FlowMetric
	bgpv4Metrics []Bgpv4Metric
	bgpv6Metrics []Bgpv6Metric
	isisMetrics  []IsisMetric
}

func (obj *metricsResponsePortMetricIter) Items() []PortMetric {
	return obj.obj.portMetrics
}

func (obj *metricsResponsePortMetricIter) Add() PortMetric {
	newObj := &snappipb.PortMetric{}
	obj.obj.obj.PortMetrics = append(obj.obj.obj.PortMetrics, newObj)
	newLibObj := &portMetric{obj: newObj}
	newLibObj.setDefault()
	obj.obj.portMetrics = append(obj.obj.portMetrics, newLibObj)
	return newLibObj
}

func (obj *metricsResponsePortMetricIter) Append(newObj PortMetric) MetricsResponsePortMetricIter {
	obj.obj.obj.PortMetrics = append(obj.obj.obj.PortMetrics, newObj.Msg())
	obj.obj.portMetrics = append(obj.obj.portMetrics, newObj)
	return obj
}

func (obj *metricsResponsePortMetricIter) Set(index int, newObj PortMetric) MetricsResponsePortMetricIter {
	obj.obj.obj.PortMetrics[index] = newObj.Msg()
	obj.obj.portMetrics[index] = newObj
	return obj
}
```
We put entire data within internal autogenerated pb file. Within this fix we are putting those list data within gosnappi package.