### PR TITLE
Add support for external grpc client

### DIFF
--- a/openapiart/common.go
+++ b/openapiart/common.go
@@ -17,15 +17,15 @@ type grpcTransport struct {
 }
 
 type GrpcTransport interface {
-    // SetLocation set client connection to the given grpc target
+	// SetLocation set client connection to the given grpc target
 	SetLocation(value string) GrpcTransport
 	// Location get grpc target
 	Location() string
-    // SetRequestTimeout set timeout in grpc request
+	// SetRequestTimeout set timeout in grpc request
 	SetRequestTimeout(value time.Duration) GrpcTransport
-    // RequestTimeout get timeout in grpc request
+	// RequestTimeout get timeout in grpc request
 	RequestTimeout() time.Duration
-    // SetDialTimeout set timeout in grpc dial
+	// SetDialTimeout set timeout in grpc dial
 	SetDialTimeout(value time.Duration) GrpcTransport
 	// DialTimeout get timeout in grpc dial
 	DialTimeout() time.Duration

--- a/openapiart/common.go
+++ b/openapiart/common.go
@@ -30,6 +30,7 @@ type GrpcTransport interface {
 	// DialTimeout get timeout in grpc dial
 	DialTimeout() time.Duration
 	// SetClientConnection set grpc DialContext
+	// SetClientConnection and (SetLocation, SetDialTimeout) are mutually exclusive
 	SetClientConnection(con *grpc.ClientConn) GrpcTransport
 	// ClientConnection get grpc DialContext
 	ClientConnection() *grpc.ClientConn

--- a/openapiart/common.go
+++ b/openapiart/common.go
@@ -17,13 +17,21 @@ type grpcTransport struct {
 }
 
 type GrpcTransport interface {
+    // SetLocation set client connection to the given grpc target
 	SetLocation(value string) GrpcTransport
+	// Location get grpc target
 	Location() string
+    // SetRequestTimeout set timeout in grpc request
 	SetRequestTimeout(value time.Duration) GrpcTransport
+    // RequestTimeout get timeout in grpc request
 	RequestTimeout() time.Duration
+    // SetDialTimeout set timeout in grpc dial
 	SetDialTimeout(value time.Duration) GrpcTransport
+	// DialTimeout get timeout in grpc dial
 	DialTimeout() time.Duration
+	// SetClientConnection set grpc DialContext
 	SetClientConnection(con *grpc.ClientConn) GrpcTransport
+	// ClientConnection get grpc DialContext
 	ClientConnection() *grpc.ClientConn
 }
 

--- a/openapiart/common.go
+++ b/openapiart/common.go
@@ -23,6 +23,8 @@ type GrpcTransport interface {
 	RequestTimeout() time.Duration
 	SetDialTimeout(value time.Duration) GrpcTransport
 	DialTimeout() time.Duration
+	SetClientConnection(con *grpc.ClientConn) GrpcTransport
+	ClientConnection() *grpc.ClientConn
 }
 
 // Location
@@ -52,6 +54,15 @@ func (obj *grpcTransport) DialTimeout() time.Duration {
 
 func (obj *grpcTransport) SetDialTimeout(value time.Duration) GrpcTransport {
 	obj.dialTimeout = value
+	return obj
+}
+
+func (obj *grpcTransport) ClientConnection() *grpc.ClientConn {
+	return obj.clientConnection
+}
+
+func (obj *grpcTransport) SetClientConnection(con *grpc.ClientConn) GrpcTransport {
+	obj.clientConnection = con
 	return obj
 }
 

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -591,14 +591,18 @@ class OpenApiArtGo(OpenApiArtPlugin):
             // grpcConnect builds up a grpc connection
             func (api *{internal_struct_name}) grpcConnect() error {{
                 if api.grpcClient == nil {{
-                    ctx, cancelFunc := context.WithTimeout(context.Background(), api.grpc.dialTimeout)
-                    defer cancelFunc()
-                    conn, err := grpc.DialContext(ctx, api.grpc.location, grpc.WithTransportCredentials(insecure.NewCredentials()))
-                    if err != nil {{
-                        return err
+                    if api.grpc.clientConnection == nil {{
+                        ctx, cancelFunc := context.WithTimeout(context.Background(), api.grpc.dialTimeout)
+                        defer cancelFunc()
+                        conn, err := grpc.DialContext(ctx, api.grpc.location, grpc.WithTransportCredentials(insecure.NewCredentials()))
+                        if err != nil {{
+                            return err
+                        }}
+                        api.grpcClient = {pb_pkg_name}.New{proto_service}Client(conn)
+                        api.grpc.clientConnection = conn
+                    }} else {{
+                        api.grpcClient = {pb_pkg_name}.New{proto_service}Client(api.grpc.clientConnection)
                     }}
-                    api.grpcClient = {pb_pkg_name}.New{proto_service}Client(conn)
-                    api.grpc.clientConnection = conn
                 }}
                 return nil
             }}

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -1,12 +1,17 @@
 package openapiart_test
 
 import (
+	"context"
+	"fmt"
 	"log"
 	"testing"
+	"time"
 
 	openapiart "github.com/open-traffic-generator/openapiart/pkg"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 var apis []openapiart.OpenapiartApi
@@ -20,9 +25,20 @@ func init() {
 	grpcApi := openapiart.NewApi()
 	grpcApi.NewGrpcTransport().SetLocation(grpcServer.Location)
 	apis = append(apis, grpcApi)
+
 	httpApi := openapiart.NewApi()
 	httpApi.NewHttpTransport().SetLocation(httpServer.Location)
 	apis = append(apis, httpApi)
+
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancelFunc()
+	conn, err := grpc.DialContext(ctx, grpcServer.Location, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatal(fmt.Sprintf("failed grpc dialcontext due to %s", err.Error()))
+	}
+	clientConnApi := openapiart.NewApi()
+	clientConnApi.NewGrpcTransport().SetClientConnection(conn)
+	apis = append(apis, clientConnApi)
 }
 
 func TestSetConfigSuccess(t *testing.T) {

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -169,3 +169,21 @@ func TestConnectionClose(t *testing.T) {
 	err1 := api.Close()
 	assert.Nil(t, err1)
 }
+
+func TestGrpcClientConnection(t *testing.T) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancelFunc()
+	conn, err := grpc.DialContext(ctx, grpcServer.Location, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Fatal(fmt.Sprintf("failed grpc dialcontext due to %s", err.Error()))
+	}
+	api := openapiart.NewApi()
+	grpc := api.NewGrpcTransport()
+	grpc.SetClientConnection(conn)
+	assert.NotNil(t, grpc.ClientConnection())
+	config := NewFullyPopulatedPrefixConfig(api)
+	config.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+	resp, err := api.SetConfig(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+}


### PR DESCRIPTION
resolves https://github.com/open-traffic-generator/openapiart/issues/328

We will expose these two methods in GrpcTransport interface
```go
	// SetClientConnection set grpc DialContext
	SetClientConnection(con *grpc.ClientConn) GrpcTransport
	// ClientConnection get grpc DialContext
	ClientConnection() *grpc.ClientConn
```
This is one snippet how user call it

```go
	ctx, cancelFunc := context.WithTimeout(context.Background(), 20*time.Second)
	defer cancelFunc()
	conn, err := grpc.DialContext(ctx, grpcServer.Location, grpc.WithTransportCredentials(insecure.NewCredentials()))
	if err != nil {
		log.Fatal(fmt.Sprintf("failed grpc dialcontext due to %s", err.Error()))
	}
	clientConnApi := openapiart.NewApi()
	clientConnApi.NewGrpcTransport().SetClientConnection(conn)
``` 

