### PR TITLE
Set format to int64 based on the min and max values provided

### DIFF
--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -1372,8 +1372,14 @@ class Generator:
                                 % yproperty["items"]["format"]
                             }
                         )
-                min_max = sub_properties.get("maximum", sub_properties.get("minimum", 0))
-                key = "itemformat" if pt.get("itemtype") is not None else "format"
+                min_max = sub_properties.get(
+                    "maximum", sub_properties.get("minimum", 0)
+                )
+                key = (
+                    "itemformat"
+                    if pt.get("itemtype") is not None
+                    else "format"
+                )
                 if min_max > 2147483647 and pt.get("itemtype") is None:
                     pt.update({key: r"'int64'"})
                 if len(ref) == 0 and "minimum" in sub_properties:

--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -1355,11 +1355,13 @@ class Generator:
                     if "type" in yproperty and yproperty["type"] == "array":
                         class_name += "Iter"
                     pt.update({"type": "'%s'" % class_name})
+                sub_properties = yproperty
                 if (
                     len(ref) == 0
                     and "items" in yproperty
                     and "type" in yproperty["items"]
                 ):
+                    sub_properties = yproperty["items"]
                     pt.update(
                         {"itemtype": self._get_data_types(yproperty["items"])}
                     )
@@ -1370,14 +1372,18 @@ class Generator:
                                 % yproperty["items"]["format"]
                             }
                         )
-                if len(ref) == 0 and "minimum" in yproperty:
-                    pt.update({"minimum": yproperty["minimum"]})
-                if len(ref) == 0 and "maximum" in yproperty:
-                    pt.update({"maximum": yproperty["maximum"]})
-                if len(ref) == 0 and "minLength" in yproperty:
-                    pt.update({"minLength": yproperty["minLength"]})
-                if len(ref) == 0 and "maxLength" in yproperty:
-                    pt.update({"maxLength": yproperty["maxLength"]})
+                min_max = sub_properties.get("maximum", sub_properties.get("minimum", 0))
+                key = "itemformat" if pt.get("itemtype") is not None else "format"
+                if min_max > 2147483647 and pt.get("itemtype") is None:
+                    pt.update({key: r"'int64'"})
+                if len(ref) == 0 and "minimum" in sub_properties:
+                    pt.update({"minimum": sub_properties["minimum"]})
+                if len(ref) == 0 and "maximum" in sub_properties:
+                    pt.update({"maximum": sub_properties["maximum"]})
+                if len(ref) == 0 and "minLength" in sub_properties:
+                    pt.update({"minLength": sub_properties["minLength"]})
+                if len(ref) == 0 and "maxLength" in sub_properties:
+                    pt.update({"maxLength": sub_properties["maxLength"]})
                 if len(pt) > 0:
                     types.append((name, pt))
 

--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -1355,13 +1355,11 @@ class Generator:
                     if "type" in yproperty and yproperty["type"] == "array":
                         class_name += "Iter"
                     pt.update({"type": "'%s'" % class_name})
-                sub_properties = yproperty
                 if (
                     len(ref) == 0
                     and "items" in yproperty
                     and "type" in yproperty["items"]
                 ):
-                    sub_properties = yproperty["items"]
                     pt.update(
                         {"itemtype": self._get_data_types(yproperty["items"])}
                     )
@@ -1372,24 +1370,22 @@ class Generator:
                                 % yproperty["items"]["format"]
                             }
                         )
-                min_max = sub_properties.get(
-                    "maximum", sub_properties.get("minimum", 0)
-                )
+                min_max = yproperty.get("maximum", yproperty.get("minimum", 0))
                 key = (
                     "itemformat"
                     if pt.get("itemtype") is not None
                     else "format"
                 )
-                if min_max > 2147483647 and pt.get("itemtype") is None:
+                if min_max > 2147483647:
                     pt.update({key: r"'int64'"})
-                if len(ref) == 0 and "minimum" in sub_properties:
-                    pt.update({"minimum": sub_properties["minimum"]})
-                if len(ref) == 0 and "maximum" in sub_properties:
-                    pt.update({"maximum": sub_properties["maximum"]})
-                if len(ref) == 0 and "minLength" in sub_properties:
-                    pt.update({"minLength": sub_properties["minLength"]})
-                if len(ref) == 0 and "maxLength" in sub_properties:
-                    pt.update({"maxLength": sub_properties["maxLength"]})
+                if len(ref) == 0 and "minimum" in yproperty:
+                    pt.update({"minimum": yproperty["minimum"]})
+                if len(ref) == 0 and "maximum" in yproperty:
+                    pt.update({"maximum": yproperty["maximum"]})
+                if len(ref) == 0 and "minLength" in yproperty:
+                    pt.update({"minLength": yproperty["minLength"]})
+                if len(ref) == 0 and "maxLength" in yproperty:
+                    pt.update({"maxLength": yproperty["maxLength"]})
                 if len(pt) > 0:
                     types.append((name, pt))
 

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -24,6 +24,8 @@ components:
           x-field-uid: 4
         full_duplex_100_mb:
           type: integer
+          minimum: 0
+          maximum: 4261412864
           x-field-uid: 5
         response:
           description: |-
@@ -159,7 +161,8 @@ components:
           type: array
           items:
             type: integer
-            format: int64
+            minimum: 0
+            maximum: 4261412864
           x-field-uid: 31
         header_checksum:
           x-field-pattern:

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -161,8 +161,8 @@ components:
           type: array
           items:
             type: integer
-            minimum: 0
-            maximum: 4261412864
+          minimum: 0
+          maximum: 4261412864
           x-field-uid: 31
         header_checksum:
           x-field-pattern:

--- a/openapiart/tests/test_int64.py
+++ b/openapiart/tests/test_int64.py
@@ -1,0 +1,24 @@
+import importlib
+
+module = importlib.import_module("sanity")
+
+def test_int64(default_config):
+    value1 = default_config._TYPES.get("full_duplex_100_mb")
+    value2 = default_config._TYPES.get("integer64_list")
+    assert value1.get("format") is not None
+    assert value2.get("itemformat") is not None
+    assert value1.get("format") == "int64"
+    assert value2.get("itemformat") == "int64"
+    default_config.full_duplex_100_mb = 100
+    default_config.integer64_list = [2000]
+    data = default_config.serialize("dict")
+    assert isinstance(data["full_duplex_100_mb"], str)
+    assert isinstance(data["integer64_list"][0], str)
+
+    config = module.Api().prefix_config()
+    config.deserialize(data)
+    assert isinstance(config.full_duplex_100_mb, int)
+    assert isinstance(config.integer64_list[0], int)
+
+
+    

--- a/openapiart/tests/test_int64.py
+++ b/openapiart/tests/test_int64.py
@@ -2,6 +2,7 @@ import importlib
 
 module = importlib.import_module("sanity")
 
+
 def test_int64(default_config):
     value1 = default_config._TYPES.get("full_duplex_100_mb")
     value2 = default_config._TYPES.get("integer64_list")
@@ -19,6 +20,3 @@ def test_int64(default_config):
     config.deserialize(data)
     assert isinstance(config.full_duplex_100_mb, int)
     assert isinstance(config.integer64_list[0], int)
-
-
-    


### PR DESCRIPTION
Currently in models some of the fields are not passed with int64 format but have minimum and maximum values which fall under int64. fixing the python snappi to set the field automatically.
https://github.com/open-traffic-generator/snappi/issues/184