### PR TITLE
python - segregate grpc transport 

### DIFF
--- a/openapiart/common.py
+++ b/openapiart/common.py
@@ -13,20 +13,22 @@ try:
 except ImportError:
     from typing_extensions import Literal
 
-#grpc-begin
+# grpc-begin
 import grpc
 from google.protobuf import json_format
 import sanity_pb2_grpc as pb2_grpc
 import sanity_pb2 as pb2
-#grpc-end
+
+# grpc-end
 if sys.version_info[0] == 3:
     unicode = str
 
 openapi_warnings = []
-#grpc-begin
+# grpc-begin
 class Transport:
     HTTP = "http"
     GRPC = "grpc"
+
 
 def api(
     location=None,
@@ -87,8 +89,10 @@ def api(
     except ImportError as err:
         msg = "Extension %s is not installed or invalid: %s"
         raise Exception(msg % (ext, err))
-#grpc-end
-#http-begin
+
+
+# grpc-end
+# http-begin
 def api(
     location=None,
     verify=True,
@@ -132,7 +136,9 @@ def api(
     except ImportError as err:
         msg = "Extension %s is not installed or invalid: %s"
         raise Exception(msg % (ext, err))
-#http-end
+
+
+# http-end
 class HttpTransport(object):
     def __init__(self, **kwargs):
         """Use args from api() method to instantiate an HTTP transport"""

--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -48,7 +48,7 @@ class Generator:
         protobuf_package_name,
         output_dir=None,
         extension_prefix=None,
-        py_generate_grpc=True
+        py_generate_grpc=True,
     ):
         self._parsers = {}
         self._base_url = ""
@@ -145,28 +145,32 @@ class Generator:
         ) as fp:
             common_content = fp.read()
             if self._py_generate_grpc:
-                grpc_chop = re.compile('#grpc-begin|#grpc-end', re.DOTALL)
-                common_content = grpc_chop.sub('', common_content)
-                http_chop = re.compile('#http-begin.*?#http-end', re.DOTALL)
-                common_content = http_chop.sub('', common_content)
+                grpc_chop = re.compile("# grpc-begin|# grpc-end", re.DOTALL)
+                common_content = grpc_chop.sub("", common_content)
+                http_chop = re.compile("# http-begin.*?# http-end", re.DOTALL)
+                common_content = http_chop.sub("", common_content)
                 cnf_text = "import sanity_pb2_grpc as pb2_grpc"
                 modify_text = "try:\n    from {pkg_name} {text}\nexcept ImportError:\n    {text}".format(
                     pkg_name=self._package_name,
-                    text=cnf_text.replace("sanity", self._protobuf_package_name),
+                    text=cnf_text.replace(
+                        "sanity", self._protobuf_package_name
+                    ),
                 )
                 common_content = common_content.replace(cnf_text, modify_text)
 
                 cnf_text = "import sanity_pb2 as pb2"
                 modify_text = "try:\n    from {pkg_name} {text}\nexcept ImportError:\n    {text}".format(
                     pkg_name=self._package_name,
-                    text=cnf_text.replace("sanity", self._protobuf_package_name),
+                    text=cnf_text.replace(
+                        "sanity", self._protobuf_package_name
+                    ),
                 )
                 common_content = common_content.replace(cnf_text, modify_text)
             else:
-                grpc_chop = re.compile('#grpc-begin.*?#grpc-end', re.DOTALL)
-                common_content = grpc_chop.sub('', common_content)
-                http_chop = re.compile('#http-begin|#http-end', re.DOTALL)
-                common_content = http_chop.sub('', common_content)
+                grpc_chop = re.compile("# grpc-begin.*?# grpc-end", re.DOTALL)
+                common_content = grpc_chop.sub("", common_content)
+                http_chop = re.compile("# http-begin|# http-end", re.DOTALL)
+                common_content = http_chop.sub("", common_content)
 
             if re.search(r"def[\s+]api\(", common_content) is not None:
                 self._generated_top_level_factories.append("api")


### PR DESCRIPTION
resolves https://github.com/open-traffic-generator/openapiart/issues/368

Add `generate_grpc` argument which by default `True` within `GeneratePythonSdk`. 

```python
open_api.GeneratePythonSdk(
    package_name="sanity",
    generate_grpc=False
)
```

