### PR TITLE
Support enumeration and filtering of flows #230

### DIFF
--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -786,7 +786,7 @@ class Bundler(object):
                     """To have metric tag columns appear in the flow metric rows the flow """
                     """metric request allows for the metric_tag value to be specified """
                     """as part of the request.""",
-                    "type": "object",
+                    "type": "array",
                     "required": ["name"],
                     "properties": {
                         "name": {

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -815,14 +815,14 @@ class Bundler(object):
                     },
                 }
                 schema["properties"]["metric_tags"] = {
-                    "$ref": "#/components/schemas/{}".format(
-                        metric_tags_schema_name
-                    )
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/components/schemas/{}".format(
+                            metric_tags_schema_name
+                        )
+                    },
+                    "x-field-uid": auto_field.uid,
                 }
-                schema["properties"]["metric_tags"]["type"] = "array"
-                schema["properties"]["metric_tags"][
-                    "x-field-uid"
-                ] = auto_field.uid
                 self._content["components"]["schemas"][
                     metric_tags_schema_name
                 ] = metric_tags_schema

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -786,7 +786,7 @@ class Bundler(object):
                     """To have metric tag columns appear in the flow metric rows the flow """
                     """metric request allows for the metric_tag value to be specified """
                     """as part of the request.""",
-                    "type": "array",
+                    "type": "object",
                     "required": ["name"],
                     "properties": {
                         "name": {
@@ -819,6 +819,7 @@ class Bundler(object):
                         metric_tags_schema_name
                     )
                 }
+                schema["properties"]["metric_tags"]["type"] = "array"
                 schema["properties"]["metric_tags"][
                     "x-field-uid"
                 ] = auto_field.uid

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -795,7 +795,7 @@ class Bundler(object):
             if "metric_tags" in xpattern["features"]:
                 # skip this UID as it was previously being used for metric_groups
                 _ = auto_field.uid
-                metric_tags_schema_name = "{}.MetricTags".format(schema_name)
+                metric_tags_schema_name = "{}.MetricTag".format(schema_name)
                 length = 65535
                 if xpattern["format"] in ["integer", "ipv4", "ipv6", "mac"]:
                     if "length" in xpattern:

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -793,6 +793,8 @@ class Bundler(object):
                     property_name="auto",
                 )
             if "metric_tags" in xpattern["features"]:
+                # skip this UID as it was previously being used for metric_groups
+                _ = auto_field.uid
                 metric_tags_schema_name = "{}.MetricTags".format(schema_name)
                 length = 65535
                 if xpattern["format"] in ["integer", "ipv4", "ipv6", "mac"]:
@@ -816,14 +818,13 @@ class Bundler(object):
                     "required": ["name"],
                     "properties": {
                         "name": {
-                            "description": "Globally unique name of an object. It also serves as the primary key for arrays of objects.",
+                            "description": "Name used for metric tag",
                             "type": "string",
                             "pattern": r"^[\sa-zA-Z0-9-_()><\[\]]+$",
                             "x-field-uid": metric_tags_auto_field.uid,
-                            "x-unique": "global",
                         },
                         "offset": {
-                            "description": "This is in bits and relative to start of the field",
+                            "description": "Offset in bits relative to start of field",
                             "type": "integer",
                             "default": 0,
                             "minimum": 0,
@@ -831,7 +832,7 @@ class Bundler(object):
                             "x-field-uid": metric_tags_auto_field.uid,
                         },
                         "length": {
-                            "description": "This is in bits",
+                            "description": "Length in bits",
                             "type": "integer",
                             "default": length,
                             "minimum": 1,

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -792,7 +792,7 @@ class Bundler(object):
                         "name": {
                             "description": "Globally unique name of an object. It also serves as the primary key for arrays of objects.",
                             "type": "string",
-                            "pattern": "^[\sa-zA-Z0-9-_()><\[\]]+$",
+                            "pattern": r"^[\sa-zA-Z0-9-_()><\[\]]+$",
                             "x-field-uid": metric_tags_auto_field.uid,
                             "x-unique": "global",
                         },

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -808,12 +808,7 @@ class Bundler(object):
                         length = 128
                 metric_tags_auto_field = AutoFieldUid()
                 metric_tags_schema = {
-                    "description": """A unique name is used to indicate to the system that the field may """
-                    """extend the metric row key and create an aggregate metric row for """
-                    """every unique value. """
-                    """To have metric tag columns appear in the flow metric rows the flow """
-                    """metric request allows for the metric_tag value to be specified """
-                    """as part of the request.""",
+                    "description": "Metric tag can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.",
                     "type": "object",
                     "required": ["name"],
                     "properties": {
@@ -842,6 +837,7 @@ class Bundler(object):
                     },
                 }
                 schema["properties"]["metric_tags"] = {
+                    "description": "One or more metric tags can be used to enable tracking portion of or all bits in a corresponding header field for metrics per each applicable value. These would appear as tagged metrics in corresponding flow metrics.",
                     "type": "array",
                     "items": {
                         "$ref": "#/components/schemas/{}".format(

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -818,13 +818,13 @@ class Bundler(object):
                     "required": ["name"],
                     "properties": {
                         "name": {
-                            "description": "Name used for metric tag",
+                            "description": "Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field",
                             "type": "string",
                             "pattern": r"^[\sa-zA-Z0-9-_()><\[\]]+$",
                             "x-field-uid": metric_tags_auto_field.uid,
                         },
                         "offset": {
-                            "description": "Offset in bits relative to start of field",
+                            "description": "Offset in bits relative to start of corresponding header field",
                             "type": "integer",
                             "default": 0,
                             "minimum": 0,
@@ -832,7 +832,7 @@ class Bundler(object):
                             "x-field-uid": metric_tags_auto_field.uid,
                         },
                         "length": {
-                            "description": "Length in bits",
+                            "description": "Number of bits to track for metrics starting from configured offset of corresponding header field",
                             "type": "integer",
                             "default": length,
                             "minimum": 1,

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -176,7 +176,6 @@ class OpenApiArtGo(OpenApiArtPlugin):
             "numberdouble": "float64",
             "stringbinary": "[]byte",
         }
-        self.iter_names = []
 
     def generate(self, openapi):
         self._base_url = ""
@@ -2224,11 +2223,12 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     field.external_struct = self._get_external_struct_name(
                         schema_name
                     )
-                    prefix = fluent_new.interface + field.external_struct
-                    field.iter_name = prefix + "Iter"
-                    if field.iter_name in self.iter_names:
-                        field.iter_name = prefix + field.name + "Iter"
-                    self.iter_names.append(field.iter_name)
+                    field.iter_name = (
+                        fluent_new.interface
+                        + field.name
+                        + field.external_struct
+                        + "Iter"
+                    )
                     field.adder_method = "Add() {name}".format(
                         name=field.iter_name
                     )

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -1940,7 +1940,6 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 field_internal_struct=field.struct,
                 parent_internal_struct=new.struct,
                 field_external_struct=field.external_struct,
-                field_name=field.name,
                 pb_pkg_name=self._protobuf_package_name,
                 field_type=field.type,
                 internal_items_name=self._get_holder_name(field, True),

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -1110,7 +1110,10 @@ class OpenApiArtGo(OpenApiArtPlugin):
                 internal_items.append(
                     "{} {}".format(
                         self._get_holder_name(field),
-                        new.interface + field.external_struct + "Iter",
+                        new.interface
+                        + field.external_struct
+                        + field.name
+                        + "Iter",
                     )
                 )
                 internal_items_nil.append(
@@ -1434,7 +1437,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                         {block}
                     }}
                     if obj.{internal_name} == nil {{
-                        obj.{internal_name} = new{parent}{interface}Iter().setMsg(obj)
+                        obj.{internal_name} = new{parent}{interface}{name}Iter().setMsg(obj)
                     }}
                     return obj.{internal_name}""".format(
                     name=field.name,
@@ -1846,7 +1849,9 @@ class OpenApiArtGo(OpenApiArtPlugin):
     def _write_field_adder(self, new, field):
         if field.adder_method is None:
             return
-        interface_name = new.interface + field.external_struct + "Iter"
+        interface_name = (
+            new.interface + field.external_struct + field.name + "Iter"
+        )
         if interface_name in self._api.components:
             return
         new_iter = FluentNew()
@@ -2223,24 +2228,23 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     field.external_struct = self._get_external_struct_name(
                         schema_name
                     )
-                    field.adder_method = (
-                        "Add() {parent}{external_struct}Iter".format(
-                            parent=fluent_new.interface,
-                            external_struct=field.external_struct,
-                        )
+                    field.adder_method = "Add() {parent}{external_struct}{field_name}Iter".format(
+                        parent=fluent_new.interface,
+                        external_struct=field.external_struct,
+                        field_name=field.name,
                     )
                     field.isOptional = False
-                    field.getter_method = (
-                        "{name}() {parent}{external_struct}Iter".format(
-                            name=self._get_external_struct_name(field.name),
-                            parent=fluent_new.interface,
-                            external_struct=field.external_struct,
-                        )
-                    )
-                    field.getter_method_description = "{name} returns {parent}{external_struct}Iter, set in {parent}".format(
+                    field.getter_method = "{name}() {parent}{external_struct}{field_name}Iter".format(
                         name=self._get_external_struct_name(field.name),
                         parent=fluent_new.interface,
                         external_struct=field.external_struct,
+                        field_name=field.name,
+                    )
+                    field.getter_method_description = "{name} returns {parent}{external_struct}{field_name}Iter, set in {parent}".format(
+                        name=self._get_external_struct_name(field.name),
+                        parent=fluent_new.interface,
+                        external_struct=field.external_struct,
+                        field_name=field.name,
                     )
                 else:
                     field.setter_method = (

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -237,6 +237,18 @@ components:
         required_choice_object:
           $ref: "#/components/schemas/RequiredChoiceParent"
           x-field-uid: 42
+        g1:
+          description: A list of objects with choice and properties
+          type: array
+          items:
+            $ref: "#/components/schemas/GObject"
+          x-field-uid: 43
+        g2:
+          description: A list of objects with choice and properties
+          type: array
+          items:
+            $ref: "#/components/schemas/GObject"
+          x-field-uid: 44
 
     WObject:
       required: [w_name]

--- a/openapiart/tests/test_add.py
+++ b/openapiart/tests/test_add.py
@@ -20,5 +20,23 @@ def test_add(api):
     config.deserialize(yaml)
 
 
+def test_add_with_multiple_list(api):
+    config = api.prefix_config()
+    config.a = "asdf"
+    config.b = 1.1
+    config.c = 1
+    config.required_object.e_a = 1.1
+    config.required_object.e_b = 1.2
+    config.g.add(name="unique list name", g_a="dkdkd", g_b=3, g_c=22.2)
+    assert len(config.g) == 1
+    config.g1.add(name="unique list name", g_a="dkdkd", g_b=3, g_c=22.2)
+    assert len(config.g1) == 1
+    config.g2.add(name="unique list name", g_a="dkdkd", g_b=3, g_c=22.2)
+    assert len(config.g2) == 1
+    yaml = config.serialize(encoding=config.YAML)
+    print(yaml)
+    config.deserialize(yaml)
+
+
 if __name__ == "__main__":
     pytest.main(["-v", "-s", __file__])

--- a/pkg/multiple_iter_test.go
+++ b/pkg/multiple_iter_test.go
@@ -1,0 +1,34 @@
+package openapiart_test
+
+import (
+	"testing"
+
+	openapiart "github.com/open-traffic-generator/openapiart/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMultipleIter(t *testing.T) {
+	api := openapiart.NewApi()
+	config := api.NewPrefixConfig()
+	config.SetA("test")
+	config.RequiredObject().SetEA(3.45).SetEB(6.78)
+	enums := []openapiart.PrefixConfigDValuesEnum{
+		openapiart.PrefixConfigDValues.A,
+		openapiart.PrefixConfigDValues.B,
+		openapiart.PrefixConfigDValues.C,
+	}
+	config.SetDValues(enums)
+	config.SetStrLen("1234")
+	config.G().Add().SetGA("this is g")
+	assert.Equal(t, len(config.G().Items()), 1)
+	config.G1().Add().SetGA("this is g1")
+	assert.Equal(t, len(config.G1().Items()), 1)
+	config.G2().Add().SetGA("this is g2")
+	assert.Equal(t, len(config.G2().Items()), 1)
+	t.Log(config)
+	// validating the warnings
+	err := config.Validate()
+	if err != nil {
+		t.Fatalf("error: %s", err.Error())
+	}
+}

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import setuptools
 
 pkg_name = "openapiart"
-version = "0.2.20"
+version = "0.2.21"
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 with open(os.path.join(base_dir, "README.md")) as fid:


### PR DESCRIPTION
Fixes https://github.com/open-traffic-generator/models/issues/230

View proposed changes in [documentation](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/open-traffic-generator/models/test_branch_egress_ingress/artifacts/openapi.yaml&nocors)

## What has changed (and why) ?
- #### How to distinguish between egress and ingress flows-
	* Previously flow.packet were used to configure shape of ingress packets only
	* There was no clear distinction between ingress and egress packet shapes, and no way to configure latter
	* Going forward the distinction between ingress and egress flows will be done with `flow.ingress_packet` and `flow.egress_packet`. 
	* `flow.packet` shall be deprecated.
- #### How to track the egress and ingress flows-
	* Under packet header configuration for each field,
		* `metric_groups` has been replaced with `metric_tags` containing a list of `metric_tag` consisting of properties name, offset and length.
	* Under flow metrics request,
		* `metric_groups` has been replaced with `metric_tags` containing a list of filter consisting of tag name and list of corresponding values associated with that tag name

### What's pending ?
- Description needs to be updated properly. Need feedback from reviewers.

### Backwards Compatibility
- No breakage in existing tests - `flow.packet` is deprecated and `metric_groups` was never implemented.
- snappi UTs needs update to replace usage of metric_groups with metric_tags and use ingress packet configuration

### Examples
- ##### Before
	```python
    # create a new config object
    test_const = {
        "mac1": ["00:00:01:01:01:01", "00:00:01:01:01:02"],
        "mac2": ["00:00:01:01:01:03", "00:00:01:01:01:04"],
        "ip1": ["1.1.1.1", "1.1.1.2"],
        "ip2": ["1.1.1.3", "1.1.1.4"],
        "tcpPortValue": 80,
    }
    
    config = grpc_api.config()
    
    tx_port, rx_port = config.ports.port(
        name="Tx Port", location="10.36.74.26;02;13"
    ).port(name="Rx Port", location="10.36.74.26;02;14")
    
    flow = config.flows.flow(name="Tx -> Rx Flow")[0]
    flow.tx_rx.port.tx_name = tx_port.name
    flow.tx_rx.port.rx_name = rx_port.name
    flow.size.fixed = 128
    flow.rate.pps = 1000
    flow.duration.fixed_packets.packets = 10000
    
    eth, vlan, ip, tcp = (
        flow.packet.ethernet().vlan().ipv4().tcp()
    )
    
    eth.src.values = test_const["mac1"]
    eth.dst.values = test_const["mac2"]
    ip.src.values = test_const["ip1"]
    ip.dst.values = test_const["ip2"]
    tcp.src_port.value = test_const["tcpPortValue"]
    tcp.dst_port.value = test_const["tcpPortValue"]
    eth.dst.metric_groups.add(name="eth_dst")
    ip.dst.metric_groups.add(name="ip_dst")
    
    response = grpc_api.set_config(config)
    assert len(response.warnings) == 1
    assert response.warnings[0] == "no"
    
    response = grpc_api.get_config()
    assert config.serialize() == response.serialize()
	
- ##### After
	```python
	# create a new config object
	test_const = {
	    "mac1": ["00:00:01:01:01:01", "00:00:01:01:01:02"],
	    "mac2": ["00:00:01:01:01:03", "00:00:01:01:01:04"],
	    "mac3": ["00:00:01:01:01:05", "00:00:01:01:01:06"],
	    "ip1": ["1.1.1.1", "1.1.1.2"],
	    "ip2": ["1.1.1.3", "1.1.1.4"],
	    "ip3": ["1.1.1.5", "1.1.1.6"],
	    "tcpPortValue": 80,
	}
	
	config = grpc_api.config()
	
	tx_port, rx_port = config.ports.port(
	    name="Tx Port", location="10.36.74.26;02;13"
	).port(name="Rx Port", location="10.36.74.26;02;14")
	
	flow = config.flows.flow(name="Tx -> Rx Flow")[0]
	flow.tx_rx.port.tx_name = tx_port.name
	flow.tx_rx.port.rx_name = rx_port.name
	flow.size.fixed = 128
	flow.rate.pps = 1000
	flow.duration.fixed_packets.packets = 10000
	
	ethIngress, vlanIngress, ipIngress, tcpIngress = (
	    flow.ingress_packet.ethernet().vlan().ipv4().tcp()
	)

	ethIngress.src.values = test_const["mac1"]
	ethIngress.dst.values = test_const["mac2"]
	ipIngress.src.values = test_const["ip1"]
	ipIngress.dst.values = test_const["ip2"]
	tcpIngress.src_port.value = test_const["tcpPortValue"]
	tcpIngress.dst_port.value = test_const["tcpPortValue"]
	ethIngress.dst.metric_tags.add(name="eth_dst_ingress", offset=40, length=8)
	ipIngress.dst.metric_tags.add(name="ip_dst_ingress", offset=24, length=8)

	ethEgress, ipEgress, tcpEgress = (
	    flow.egress_packet.ethernet().ipv4().tcp()
	)

	ethEgress.src.values = test_const["mac2"]
	ethEgress.dst.values = test_const["mac3"]
	ipEgress.src.values = test_const["ip2"]
	ipEgress.dst.values = test_const["ip3"]
	tcpEgress.src_port.value = test_const["tcpPortValue"]
	tcpEgress.dst_port.value = test_const["tcpPortValue"]
	ethEgress.dst.metric_tags.add(name="eth_dst_egress", offset=40, length=8)
	ipEgress.dst.metric_tags.add(name="ip_dst_egress", offset=24, length=8)
	
	response = grpc_api.set_config(config)
	assert len(response.warnings) == 1
	assert response.warnings[0] == "no"

	response = grpc_api.get_config()
	assert config.serialize() == response.serialize()
	grpc_api.get_metrics()

| Flow          | IPDstIngress | MacDstIngress     | MacDstEgress      | FramesRx |
|---------------|--------------|-------------------|-------------------|----------|
| Tx -> Rx Flow | 1.1.1.1      | 00:00:01:01:01:01 | 01:03 | 5000     |
| Tx -> Rx Flow | 1.1.1.3      | 00:00:01:01:01:03 | 01:05 | 5000     |
| Tx -> Rx Flow |              |                   |                   | 10000    |