### PR TITLE
Fix python lint check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           python do.py install
       - name: Run python lint
         run: |
-          python do.py lint
+          python do.py lint true
       - name: Archive generated artifacts
         if: always()
         uses: actions/upload-artifact@v2

--- a/do.py
+++ b/do.py
@@ -179,7 +179,7 @@ def lint(check="false"):
     ret, out = getstatusoutput(py() + " -m black " + " ".join(paths) + cmd)
     if ret == 1:
         raise Exception(
-            "Black formatting failed, with black {} version to format the files\n{}".format(
+            "Black formatting failed, with black version {}.\n{}".format(
                 BLACK_VERSION, out
             )
         )

--- a/do.py
+++ b/do.py
@@ -163,7 +163,7 @@ def init(use_sdk=None):
         )
 
 
-def lint():
+def lint(check="false"):
     paths = [
         pkg()[0],
         "openapiart",
@@ -172,27 +172,19 @@ def lint():
     ]
     # --check will check for any files to be formatted with black
     # if linting fails, format the files with black and commit
-    ret, out = getstatusoutput(
-        py()
-        + " -m black "
-        + " ".join(paths)
-        + " --exclude=openapiart/common.py --check --required-version {}".format(
-            BLACK_VERSION
-        )
-    )
+    cmd = " --exclude=openapiart/common.py"
+    if check.lower() == "true":
+        cmd += " --check"
+    cmd += " --required-version {}".format(BLACK_VERSION)
+    ret, out = getstatusoutput(py() + " -m black " + " ".join(paths) + cmd)
     if ret == 1:
-        out = out.split("\n")
-        out = [
-            e.replace("would reformat", "Black formatting failed for")
-            for e in out
-            if "would reformat" in e
-        ]
-        print("\n".join(out))
         raise Exception(
-            "Black formatting failed, use black {} version to format the files".format(
-                BLACK_VERSION
+            "Black formatting failed, with black {} version to format the files\n{}".format(
+                BLACK_VERSION, out
             )
         )
+    else:
+        print(out)
     run(
         [
             py() + " -m flake8 " + " ".join(paths),

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -1085,11 +1085,6 @@ class OpenApiArtGo(OpenApiArtPlugin):
             new.generated = True
 
         self._build_setters_getters(new)
-
-
-
-
-
         internal_items = []
         internal_items_nil = []
         for field in new.interface_fields:

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -1085,6 +1085,11 @@ class OpenApiArtGo(OpenApiArtPlugin):
             new.generated = True
 
         self._build_setters_getters(new)
+
+
+
+
+
         internal_items = []
         internal_items_nil = []
         for field in new.interface_fields:


### PR DESCRIPTION
python do.py lint now formats the python files using black and provides information on which files changed and remained same on the out 
CI uses python do.py true (check=true) and prints all the files that needs reformatting and remained unchanged 
example CI failure due to lint issues 
https://github.com/open-traffic-generator/openapiart/actions/runs/5286727208/jobs/9566426810#step:6:17

Pass CI also prints that all files are good and no of unchanged files
https://github.com/open-traffic-generator/openapiart/actions/runs/5286810785/jobs/9566599826#step:6:9