### PR TITLE
Openapiart cli

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,48 @@ jobs:
             dist
             pkg
 
+  build_yaml:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      matrix:
+        python-version: [3.9]
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: install python requirements
+        run: |
+          python do.py setup
+          python do.py init
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.20"
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v2
+        with:
+          version: "23.3"
+      - name: Setup Go and protoc
+        run: |
+          python do.py setup_ext "1.20"
+      - name: Generate Python SDK
+        run: |
+          python do.py generate_from_yaml python
+      - name: Test python SDK
+        run: |
+          python do.py testpy
+      - name: Generate Go SDK
+        run: |
+          python do.py generate_from_yaml go
+      - name: Test Go SDK
+        run: |
+          python do.py testgo
+
   dev_workflow_ubuntu:
     runs-on: ubuntu-latest
     steps:
@@ -69,49 +111,49 @@ jobs:
         run: |
           python do.py build
 
-#   dev_workflow_macos:
-#     runs-on: macos-latest
-#     steps:
-#       - name: Checkout source
-#         uses: actions/checkout@v2
-#         with:
-#           ref: ${{ github.head_ref }}
-#       - name: Set up Python 3.10
-#         uses: actions/setup-python@v2
-#         with:
-#           python-version: "3.10"
-#       - uses: actions/setup-go@v2
-#         with:
-#           go-version: "1.20"
-#       - name: Install Protoc
-#         uses: arduino/setup-protoc@v2
-#         with:
-#           version: "23.3"
-#       - name: Trigger dev workflow
-#         run: |
-#           python do.py build
+  #   dev_workflow_macos:
+  #     runs-on: macos-latest
+  #     steps:
+  #       - name: Checkout source
+  #         uses: actions/checkout@v2
+  #         with:
+  #           ref: ${{ github.head_ref }}
+  #       - name: Set up Python 3.10
+  #         uses: actions/setup-python@v2
+  #         with:
+  #           python-version: "3.10"
+  #       - uses: actions/setup-go@v2
+  #         with:
+  #           go-version: "1.20"
+  #       - name: Install Protoc
+  #         uses: arduino/setup-protoc@v2
+  #         with:
+  #           version: "23.3"
+  #       - name: Trigger dev workflow
+  #         run: |
+  #           python do.py build
 
-#   dev_workflow_windows:
-#     runs-on: windows-latest
-#     steps:
-#       - name: Checkout source
-#         uses: actions/checkout@v2
-#         with:
-#           ref: ${{ github.head_ref }}
-#       - name: Set up Python 3.10
-#         uses: actions/setup-python@v2
-#         with:
-#           python-version: "3.10"
-#       - uses: actions/setup-go@v2
-#         with:
-#           go-version: "1.20"
-#       - name: Install Protoc
-#         uses: arduino/setup-protoc@v2
-#         with:
-#           version: "23.3"
-#       - name: Trigger dev workflow
-#         run: |
-#           python do.py build
+  #   dev_workflow_windows:
+  #     runs-on: windows-latest
+  #     steps:
+  #       - name: Checkout source
+  #         uses: actions/checkout@v2
+  #         with:
+  #           ref: ${{ github.head_ref }}
+  #       - name: Set up Python 3.10
+  #         uses: actions/setup-python@v2
+  #         with:
+  #           python-version: "3.10"
+  #       - uses: actions/setup-go@v2
+  #         with:
+  #           go-version: "1.20"
+  #       - name: Install Protoc
+  #         uses: arduino/setup-protoc@v2
+  #         with:
+  #           version: "23.3"
+  #       - name: Trigger dev workflow
+  #         run: |
+  #           python do.py build
 
   dev_workflow_docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,8 @@ jobs:
           python do.py setup_ext "1.20"
       - name: Generate Python SDK
         run: |
+          python -m pip install -r ./openapiart/requirements.txt
+          python -m pip install -r ./openapiart/test_requirements.txt
           python do.py generate_from_yaml python
       - name: Test python SDK
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,20 +48,17 @@ jobs:
             pkg
 
   build_yaml:
+    needs: build
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 1
-      matrix:
-        python-version: [3.9]
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
       - name: install python requirements
         run: |
           python do.py setup
@@ -76,10 +73,15 @@ jobs:
       - name: Setup Go and protoc
         run: |
           python do.py setup_ext "1.20"
+      - uses: actions/download-artifact@v2
+        id: download
+        with:
+          name: python_package
+      - name: Install dependencies
+        run: |
+          python do.py install_package_only
       - name: Generate Python SDK
         run: |
-          python -m pip install -r ./openapiart/requirements.txt
-          python -m pip install -r ./openapiart/test_requirements.txt
           python do.py generate_from_yaml python
       - name: Test python SDK
         run: |

--- a/do.py
+++ b/do.py
@@ -227,7 +227,7 @@ def generate_from_yaml(sdk="all"):
     )
     run(
         [
-            py() + "  -m openapiart --config_file" + yaml_file,
+            py() + "  -m openapiart --config_file " + yaml_file,
         ]
     )
 

--- a/do.py
+++ b/do.py
@@ -225,9 +225,11 @@ def generate_from_yaml(sdk="all"):
     yaml_file = os.path.normpath(
         os.path.join(os.path.dirname(__file__), yaml_file)
     )
-    from openapiart.generate_from_yaml import GenerateFromYaml
-
-    GenerateFromYaml(yaml_file)
+    run(
+        [
+            py() + "  -m openapiart --config_file" + yaml_file,
+        ]
+    )
 
 
 def testpy():

--- a/do.py
+++ b/do.py
@@ -214,6 +214,22 @@ def generate(sdk="", cicd=""):
     )
 
 
+def generate_from_yaml(sdk="all"):
+    if sdk == "python":
+        yaml_file = "yaml_files/generate_python.yaml"
+    elif sdk == "go":
+        yaml_file = "yaml_files/generate_go.yaml"
+    else:
+        yaml_file = "yaml_files/generate_all.yaml"
+
+    yaml_file = os.path.normpath(
+        os.path.join(os.path.dirname(__file__), yaml_file)
+    )
+    from openapiart.generate_from_yaml import GenerateFromYaml
+
+    GenerateFromYaml(yaml_file)
+
+
 def testpy():
     run(
         [

--- a/openapiart/__init__.py
+++ b/openapiart/__init__.py
@@ -1,1 +1,2 @@
 from .openapiart import OpenApiArt
+from .generate_from_yaml import GenerateFromYaml

--- a/openapiart/__main__.py
+++ b/openapiart/__main__.py
@@ -1,0 +1,3 @@
+from .openapiartcli import generate
+
+generate()

--- a/openapiart/generate_from_yaml.py
+++ b/openapiart/generate_from_yaml.py
@@ -95,11 +95,13 @@ class GenerateFromYaml(object):
         artifact_dir = self._config.get("artifact_dir", "art")
         artifact_dir = os.path.normpath(os.path.abspath(artifact_dir))
         proto_service = self._config.get("proto_service", "Openapi")
+        protobuf_name = self._config.get("protobuf_name", "sanity")
         extension_prefix = self._config.get("extension_prefix", "sanity")
         generate_version_api = self._config.get("generate_version_api", True)
 
         self._openapiart = openapiart_class(
             api_files=validated_files,
+            protobuf_name=protobuf_name,
             artifact_dir=artifact_dir,
             extension_prefix=extension_prefix,
             proto_service=proto_service,

--- a/openapiart/generate_from_yaml.py
+++ b/openapiart/generate_from_yaml.py
@@ -1,43 +1,180 @@
 import os
-import sys
+
+# import sys
 import yaml
 
-sys.path.insert(0, os.getcwd())
-print(os.getcwd())
-print(sys.path)
+# sys.path.insert(0, os.getcwd())
+# print(os.getcwd())
+# print(sys.path)
+from .openapiart import OpenApiArt as openapiart_class
 
 
 class GenerateFromYaml(object):
+    """
+    This class takes in yaml file which basically acts as a config file according
+    to which openapiart operations are truggered.
+    example yaml:
+
+    api_files:
+        - openapiart/tests/api/info.yaml
+        - openapiart/tests/api/api.yaml
+        - openapiart/goserver/api/service_a.api.yaml
+        - openapiart/goserver/api/service_b.api.yaml
+    artifact_dir: art
+    generate_version_api: true
+    languages:
+        python:
+            package_name: sanity
+        go:
+            sdk:
+                package_dir: github.com/open-traffic-generator/openapiart/pkg
+                package_name: openapiart
+                sdk_version: 0.0.1
+            server:
+                module_path: github.com/open-traffic-generator/openapiart/pkg
+                models_prefix: sanity
+                models_path: github.com/open-traffic-generator/openapiart/pkg
+            tidy:
+                relative_package_dir: pkg
+
+    """
+
     def __init__(self, yaml_file):
-        pass
+        """
+        Takes in yaml config ,does basic checking initiates generation.
+        """
 
+        self._file = yaml_file
 
-from openapiart import OpenApiArt as openapiart_class
+        self._file = os.path.normpath(os.path.abspath(self._file))
 
-openapiart_class(
-    api_files=[
-        os.path.join(
-            "/home/otg/openapiart", "./openapiart/tests/api/info.yaml"
-        ),
-        os.path.join(
-            "/home/otg/openapiart",
-            "./openapiart/tests/common/common.yaml",
-        ),
-        os.path.join(
-            "/home/otg/openapiart", "./openapiart/tests/api/api.yaml"
-        ),
-        # os.path.join(/home/otg/openapiart, "./openapiart/goserver/api/api.yaml"),
-        os.path.join(
-            "/home/otg/openapiart",
-            "./openapiart/goserver/api/service_a.api.yaml",
-        ),
-        os.path.join(
-            "/home/otg/openapiart",
-            "./openapiart/goserver/api/service_b.api.yaml",
-        ),
-    ],
-    artifact_dir=os.path.join("/home/otg/openapiart", "art"),
-    extension_prefix="sanity",
-    proto_service="Openapi",
-    generate_version_api=True,
-)
+        if not os.path.exists(self._file):
+            raise Exception("the file %s does not exsist" % self._file)
+
+        with open(self._file) as fp:
+            self._config = yaml.safe_load(fp.read())
+
+        self._initiate_generation()
+
+    def _initiate_generation(self):
+        """
+        common place to initial openapiart operations
+        """
+
+        self._initiate_bundling()
+        if self._config.get("languages") is not None:
+            langs = self._config.get("languages")
+            if langs.get("python") is not None:
+                self._generate_python(langs["python"])
+            if langs.get("go") is not None:
+                self._generate_go(langs["go"])
+
+    def _initiate_bundling(self):
+        """
+        mainly handles the bunling and json, yaml generation
+        """
+
+        if self._config.get("api_files") is None:
+            raise Exception("api_files is a mandatory property in yaml")
+
+        if self._config.get("artifact_dir") is None:
+            raise Exception("artifact_dir is a mandatory property in yaml")
+
+        print("\n\nStarting Bundling  Process:\n\n")
+
+        files = self._config.get("api_files")
+        validated_files = []
+        for file in files:
+            file_name = os.path.normpath(os.path.abspath(file))
+            if not os.path.exists(file_name):
+                raise Exception(
+                    "%s file in api_files does not exsists" % file_name
+                )
+            validated_files.append(file_name)
+
+        artifact_dir = self._config.get("artifact_dir", "art")
+        artifact_dir = os.path.normpath(os.path.abspath(artifact_dir))
+        proto_service = self._config.get("proto_service", "Openapi")
+        extension_prefix = self._config.get("extension_prefix", "sanity")
+        generate_version_api = self._config.get("generate_version_api", True)
+
+        self._openapiart = openapiart_class(
+            api_files=validated_files,
+            artifact_dir=artifact_dir,
+            extension_prefix=extension_prefix,
+            proto_service=proto_service,
+            generate_version_api=generate_version_api,
+        )
+
+    def _generate_python(self, config):
+        """
+        Initiates python sdk geenration.
+        """
+        print("\n\nStarting Python SDK generation \n\n")
+        if config.get("package_name") is None:
+            raise Exception(
+                "package_name is a mandatory parameter to generate python sdk"
+            )
+
+        self._openapiart.GeneratePythonSdk(
+            package_name=config.get("package_name")
+        )
+
+    def _generate_go(self, config):
+        """
+        Initiates go sdk and server generations
+        """
+        if config.get("sdk") is not None:
+            print("\n\nStarting Go SDK generation\n\n")
+            go_sdk = config.get("sdk")
+
+            if "package_dir" not in go_sdk or "package_name" not in go_sdk:
+                raise Exception(
+                    "package_dir and package_name are manadatory for go sdk generation"
+                )
+
+            package_dir = go_sdk.get("package_dir")
+            package_name = go_sdk.get("package_name")
+            sdk_version = go_sdk.get("sdk_version")
+
+            self._openapiart.GenerateGoSdk(
+                package_dir=package_dir,
+                package_name=package_name,
+                sdk_version=sdk_version,
+            )
+
+        if config.get("server") is not None:
+            print("\n\nStarting Go Server generation\n\n")
+            go_server = config.get("server")
+
+            if (
+                "module_path" not in go_server
+                or "models_prefix" not in go_server
+                or "models_path" not in go_server
+            ):
+                raise Exception(
+                    "module_path, models_prefix and models_path are manadatory for go server generation"
+                )
+
+            module_path = go_server.get("module_path")
+            models_prefix = go_server.get("models_prefix")
+            models_path = go_server.get("models_path")
+
+            self._openapiart.GenerateGoServer(
+                module_path=module_path,
+                models_prefix=models_prefix,
+                models_path=models_path,
+            )
+
+        if config.get("tidy") is not None:
+            print("\n\nStarting Go Tidy Process\n\n")
+            go_tidy = config.get("tidy")
+
+            if "relative_package_dir" not in go_tidy:
+                raise Exception(
+                    "relative_package_dir is a mandatory for go tidy"
+                )
+
+            self._openapiart.GoTidy(
+                relative_package_dir=go_tidy["relative_package_dir"]
+            )

--- a/openapiart/generate_from_yaml.py
+++ b/openapiart/generate_from_yaml.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import yaml
+
+sys.path.insert(0, os.getcwd())
+print(os.getcwd())
+print(sys.path)
+
+
+class GenerateFromYaml(object):
+    def __init__(self, yaml_file):
+        pass
+
+
+from openapiart import OpenApiArt as openapiart_class
+
+openapiart_class(
+    api_files=[
+        os.path.join(
+            "/home/otg/openapiart", "./openapiart/tests/api/info.yaml"
+        ),
+        os.path.join(
+            "/home/otg/openapiart",
+            "./openapiart/tests/common/common.yaml",
+        ),
+        os.path.join(
+            "/home/otg/openapiart", "./openapiart/tests/api/api.yaml"
+        ),
+        # os.path.join(/home/otg/openapiart, "./openapiart/goserver/api/api.yaml"),
+        os.path.join(
+            "/home/otg/openapiart",
+            "./openapiart/goserver/api/service_a.api.yaml",
+        ),
+        os.path.join(
+            "/home/otg/openapiart",
+            "./openapiart/goserver/api/service_b.api.yaml",
+        ),
+    ],
+    artifact_dir=os.path.join("/home/otg/openapiart", "art"),
+    extension_prefix="sanity",
+    proto_service="Openapi",
+    generate_version_api=True,
+)

--- a/openapiart/openapiartcli.py
+++ b/openapiart/openapiartcli.py
@@ -1,0 +1,24 @@
+import click
+import os
+
+from .generate_from_yaml import GenerateFromYaml
+
+
+@click.command()
+@click.option(
+    "--config_file",
+    help="the config file for openapiart operations",
+    required=True,
+)
+def generate(config_file):
+
+    config_file = os.path.normpath(os.path.abspath(config_file))
+
+    if not os.path.exists(config_file):
+        raise Exception("the file %s does not exsist" % config_file)
+
+    GenerateFromYaml(config_file)
+
+
+if __name__ == "__main__":
+    generate()

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,10 @@ setuptools.setup(
     packages=[pkg_name],
     python_requires=">=2.7, <4",
     install_requires=installation_requires,
+    entry_points="""
+    [console_scripts]
+    openapiart=openapiart.openapiartcli:generate
+    """,
     extras_require={"testing": test_requires},
     test_suite="tests",
 )

--- a/yaml_files/generate_all.yaml
+++ b/yaml_files/generate_all.yaml
@@ -1,0 +1,21 @@
+api_files:
+  - openapiart/tests/api/info.yaml
+  - openapiart/tests/api/api.yaml
+  - openapiart/goserver/api/service_a.api.yaml
+  - openapiart/goserver/api/service_b.api.yaml
+artifact_dir: art
+generate_version_api: true
+languages:
+  python:
+    package_name: sanity
+  go:
+    sdk:
+      package_dir: github.com/open-traffic-generator/openapiart/pkg
+      package_name: openapiart
+      sdk_version: 0.0.1
+    server:
+      module_path: github.com/open-traffic-generator/openapiart/pkg
+      models_prefix: sanity
+      models_path: github.com/open-traffic-generator/openapiart/pkg
+    tidy:
+      relative_package_dir: pkg

--- a/yaml_files/generate_go.yaml
+++ b/yaml_files/generate_go.yaml
@@ -7,8 +7,6 @@ api_files:
 artifact_dir: art
 generate_version_api: true
 languages:
-  python:
-    package_name: sanity
   go:
     sdk:
       package_dir: github.com/open-traffic-generator/openapiart/pkg

--- a/yaml_files/generate_python.yaml
+++ b/yaml_files/generate_python.yaml
@@ -1,0 +1,11 @@
+api_files:
+  - openapiart/tests/api/info.yaml
+  - openapiart/tests/common/common.yaml
+  - openapiart/tests/api/api.yaml
+  - openapiart/goserver/api/service_a.api.yaml
+  - openapiart/goserver/api/service_b.api.yaml
+artifact_dir: art
+generate_version_api: true
+languages:
+  python:
+    package_name: sanity


### PR DESCRIPTION
now openapiart can parse ymls and generate based on yml configuration 

example yml 
```yml
api_files:
  - openapiart/tests/api/info.yaml
  - openapiart/tests/common/common.yaml
  - openapiart/tests/api/api.yaml
  - openapiart/goserver/api/service_a.api.yaml
  - openapiart/goserver/api/service_b.api.yaml
artifact_dir: art
generate_version_api: true
languages:
  python:
    package_name: sanity
  go:
    sdk:
      package_dir: github.com/open-traffic-generator/openapiart/pkg
      package_name: openapiart
      sdk_version: 0.0.1
    server:
      module_path: github.com/open-traffic-generator/openapiart/pkg
      models_prefix: sanity
      models_path: github.com/open-traffic-generator/openapiart/pkg
    tidy:
      relative_package_dir: pkg

```

can be used as a cli tool 
```sh
openapiart --help
openapiart --config_file ./config.yaml
python -m openapiart --help
python -m  openapiart --config_file ./config.yaml
```