### PR TITLE
support for auto heirarchy

### DIFF
--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -868,20 +868,38 @@ class Bundler(object):
                 if "auto" in xpattern:
                     # new enhance for auto hierarchy
                     auto_prop = xpattern["auto"]
-                    if "$ref" in auto_prop:
-                        schema["properties"]["choice"]["x-enum"]["auto"] = {
-                            "x-field-uid": 1
-                        }
-                        schema["properties"]["auto"] = {
-                            "$ref": auto_prop["$ref"],
-                            "x-field-uid": auto_field.uid,
-                        }
-                    else:
+                    if "$ref" not in auto_prop:
                         self._errors.append(
                             "ref is a mandatory property in {}, when auto property is specified".format(
                                 schema_name
                             )
                         )
+                    if "default" not in auto_prop:
+                        self._errors.append(
+                            "default is a mandatory property in {}, when auto property is specified".format(
+                                schema_name
+                            )
+                        )
+                    elif not isinstance(auto_prop["default"], bool):
+                        self._errors.append(
+                            "only boolean values are allowed for default in {}".format(
+                                schema_name
+                            )
+                        )
+                    if "$ref" in auto_prop:
+                        schema["properties"]["choice"]["x-enum"]["auto"] = {
+                            "x-field-uid": 1
+                        }
+                        if (
+                            "default" in auto_prop
+                            and auto_prop["default"] is True
+                        ):
+                            schema["properties"]["choice"]["default"] = "auto"
+                        schema["properties"]["auto"] = {
+                            "$ref": auto_prop["$ref"],
+                            "x-field-uid": auto_field.uid,
+                        }
+
                 else:
                     if "default" not in xpattern:
                         self._errors.append(

--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -706,6 +706,18 @@ class Bundler(object):
                     str(valid_formats),
                 )
             )
+        valid_features = ["count", "auto", "metric_tags"]
+        if "features" in xpattern:
+            for feature in xpattern["features"]:
+                if feature not in valid_features:
+                    self._errors.append(
+                        "%s has unspported feature %s , valid features are %s"
+                        % (
+                            str(xpattern_path.full_path),
+                            feature,
+                            str(valid_features),
+                        )
+                    )
 
     def _resolve_x_field_pattern(self):
         """Find all instances of pattern_extension in the openapi content
@@ -851,33 +863,52 @@ class Bundler(object):
         if xconstants is not None:
             schema["x-constants"] = copy.deepcopy(xconstants)
         if "features" in xpattern:
+
             if "auto" in xpattern["features"]:
-                if "default" not in xpattern:
-                    self._errors.append(
-                        "default must be set for property {}, when auto feature is enabled".format(
-                            schema_name
+                if "auto" in xpattern:
+                    # new enhance for auto hierarchy
+                    auto_prop = xpattern["auto"]
+                    if "$ref" in auto_prop:
+                        schema["properties"]["choice"]["x-enum"]["auto"] = {
+                            "x-field-uid": 1
+                        }
+                        schema["properties"]["auto"] = {
+                            "$ref": auto_prop["$ref"],
+                            "x-field-uid": auto_field.uid,
+                        }
+                    else:
+                        self._errors.append(
+                            "ref is a mandatory property in {}, when auto property is specified".format(
+                                schema_name
+                            )
                         )
+                else:
+                    if "default" not in xpattern:
+                        self._errors.append(
+                            "default must be set for property {}, when auto feature is enabled".format(
+                                schema_name
+                            )
+                        )
+                    schema["properties"]["choice"]["x-enum"]["auto"] = {
+                        "x-field-uid": 1
+                    }
+                    schema["properties"]["choice"]["default"] = "auto"
+                    description = [
+                        "The OTG implementation can provide a system generated",
+                        "value for this property. If the OTG is unable to generate a value",
+                        "the default value must be used.",
+                    ]
+                    schema["properties"]["auto"] = {
+                        "description": "\n".join(description),
+                        "type": copy.deepcopy(type_name),
+                        "x-field-uid": auto_field.uid,
+                    }
+                    self._apply_common_x_field_pattern_properties(
+                        schema["properties"]["auto"],
+                        xpattern,
+                        fmt,
+                        property_name="auto",
                     )
-                schema["properties"]["choice"]["x-enum"]["auto"] = {
-                    "x-field-uid": 1
-                }
-                schema["properties"]["choice"]["default"] = "auto"
-                description = [
-                    "The OTG implementation can provide a system generated",
-                    "value for this property. If the OTG is unable to generate a value",
-                    "the default value must be used.",
-                ]
-                schema["properties"]["auto"] = {
-                    "description": "\n".join(description),
-                    "type": copy.deepcopy(type_name),
-                    "x-field-uid": auto_field.uid,
-                }
-                self._apply_common_x_field_pattern_properties(
-                    schema["properties"]["auto"],
-                    xpattern,
-                    fmt,
-                    property_name="auto",
-                )
 
             # skip this UID as it was previously being used for metric_groups
             _ = auto_field.uid

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -2712,7 +2712,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
                         vObj.validationErrors = append(vObj.validationErrors, fmt.Sprintf("%s %s", err.Error(), "on {interface}.{name}"))
                     }}
                 """.format(
-                    name=field.name,
+                    name=self._get_external_struct_name(field.name),
                     interface=new.interface,
                     format=field.format.capitalize()
                     if field.isArray is False

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -322,6 +322,13 @@ components:
         choice_required_default:
           $ref: "#/components/schemas/ChoiceRequiredAndDefault"
           x-field-uid: 57
+        auto_pattern:
+          $ref: "../pattern/pattern.yaml#/components/schemas/AutoPattern"
+          x-field-uid: 58
+        name_ending_with_number_234:
+          type: string
+          format: ipv4
+          x-field-uid: 59
 
     WObject:
       required: [w_name]
@@ -767,3 +774,16 @@ components:
             type: string
             format: ipv6
           x-field-uid: 3
+
+    AutoIpOptions:
+      type: object
+      required: [choice]
+      properties:
+        choice:
+          type: string
+          x-field-uid: 1
+          x-enum:
+            static:
+              x-field-uid: 1
+            dhcp:
+              x-field-uid: 2

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -325,10 +325,13 @@ components:
         auto_pattern:
           $ref: "../pattern/pattern.yaml#/components/schemas/AutoPattern"
           x-field-uid: 58
+        auto_pattern_default:
+          $ref: "../pattern/pattern.yaml#/components/schemas/AutoPatternDefault"
+          x-field-uid: 59
         name_ending_with_number_234:
           type: string
           format: ipv4
-          x-field-uid: 59
+          x-field-uid: 60
 
     WObject:
       required: [w_name]
@@ -776,11 +779,32 @@ components:
           x-field-uid: 3
 
     AutoIpOptions:
+      description: |-
+        The OTG implementation can provide a system generated,
+        value for this property. If the OTG is unable to generate a value,
+        the default value must be used.
       type: object
       required: [choice]
       properties:
         choice:
           type: string
+          x-field-uid: 1
+          x-enum:
+            static:
+              x-field-uid: 1
+            dhcp:
+              x-field-uid: 2
+
+    AutoIpDefault:
+      description: |-
+        The OTG implementation can provide a system generated,
+        value for this property. If the OTG is unable to generate a value,
+        the default value must be used.
+      type: object
+      properties:
+        choice:
+          type: string
+          default: dhcp
           x-field-uid: 1
           x-enum:
             static:

--- a/openapiart/tests/pattern/invalid-pattern.yaml
+++ b/openapiart/tests/pattern/invalid-pattern.yaml
@@ -81,3 +81,21 @@ components:
             default: 0
             features: [count]
           x-field-uid: 9
+        wrong_features_value:
+          x-field-pattern:
+            format: integer
+            length: 2
+            signed: 45
+            default: 0
+            features: [abc]
+          x-field-uid: 10
+        wrong_auto_value:
+          x-field-pattern:
+            format: integer
+            length: 2
+            signed: 45
+            default: 0
+            features: [auto]
+            auto:
+              prop: 123
+          x-field-uid: 10

--- a/openapiart/tests/pattern/invalid-pattern.yaml
+++ b/openapiart/tests/pattern/invalid-pattern.yaml
@@ -99,3 +99,14 @@ components:
             auto:
               prop: 123
           x-field-uid: 10
+        wrong_auto_default_value:
+          x-field-pattern:
+            format: integer
+            length: 2
+            signed: 45
+            default: 0
+            features: [auto]
+            auto:
+              prop: 123
+              default: truely
+          x-field-uid: 10

--- a/openapiart/tests/pattern/pattern.yaml
+++ b/openapiart/tests/pattern/pattern.yaml
@@ -70,3 +70,15 @@ components:
             format: oid
             default: "0.1"
           x-field-uid: 1
+    AutoPattern:
+      description: Test mac pattern
+      type: object
+      properties:
+        auto_ip:
+          x-field-pattern:
+            format: ipv4
+            default: "0.0.0.0"
+            features: [count, auto]
+            auto:
+              $ref: "../config/config.yaml#/components/schemas/AutoIpOptions"
+          x-field-uid: 1

--- a/openapiart/tests/pattern/pattern.yaml
+++ b/openapiart/tests/pattern/pattern.yaml
@@ -71,7 +71,7 @@ components:
             default: "0.1"
           x-field-uid: 1
     AutoPattern:
-      description: Test mac pattern
+      description: Test auto pattern
       type: object
       properties:
         auto_ip:
@@ -81,4 +81,19 @@ components:
             features: [count, auto]
             auto:
               $ref: "../config/config.yaml#/components/schemas/AutoIpOptions"
+              default: false
+          x-field-uid: 1
+
+    AutoPatternDefault:
+      description: Test auto pattern with default
+      type: object
+      properties:
+        auto_ip_default:
+          x-field-pattern:
+            format: ipv4
+            default: "0.0.0.0"
+            features: [count, auto]
+            auto:
+              $ref: "../config/config.yaml#/components/schemas/AutoIpDefault"
+              default: true
           x-field-uid: 1

--- a/openapiart/tests/test_auto.py
+++ b/openapiart/tests/test_auto.py
@@ -20,3 +20,32 @@ def test_auto(config):
 
     config.auto_field_test.auto
     assert config.auto_field_test.choice == "auto"
+
+
+def test_auto_hierarchy(config):
+    at = config.auto_pattern.auto_ip
+    try:
+        at.auto = 10
+        pytest.fail("able to set the auto field")
+    except Exception:
+        pass
+
+    dt = config.serialize(config.DICT)
+
+    assert dt.get("auto_pattern", {}).get("auto_ip").get("choice") == "value"
+
+    at.auto.choice = "static"
+    assert config.auto_pattern.auto_ip.auto.choice == "static"
+
+    at.auto.choice = "dhcp"
+    assert config.auto_pattern.auto_ip.auto.choice == "dhcp"
+
+    dt = config.serialize(config.DICT)
+    assert (
+        dt.get("auto_pattern", {}).get("auto_ip").get("auto").get("choice")
+        == "dhcp"
+    )
+
+    config.deserialize(dt)
+    assert config.auto_pattern.auto_ip.choice == "auto"
+    assert config.auto_pattern.auto_ip.auto.choice == "dhcp"

--- a/openapiart/tests/test_auto.py
+++ b/openapiart/tests/test_auto.py
@@ -49,3 +49,38 @@ def test_auto_hierarchy(config):
     config.deserialize(dt)
     assert config.auto_pattern.auto_ip.choice == "auto"
     assert config.auto_pattern.auto_ip.auto.choice == "dhcp"
+
+
+def test_auto_hierarchy_with_default(config):
+    at = config.auto_pattern_default.auto_ip_default
+    try:
+        at.auto = 10
+        pytest.fail("able to set the auto field")
+    except Exception:
+        pass
+
+    dt = config.serialize(config.DICT)
+    print(dt)
+    assert (
+        dt.get("auto_pattern_default", {}).get("auto_ip_default").get("choice")
+        == "auto"
+    )
+
+    at.auto.choice = "static"
+    assert config.auto_pattern_default.auto_ip_default.auto.choice == "static"
+
+    at.auto.choice = "dhcp"
+    assert config.auto_pattern_default.auto_ip_default.auto.choice == "dhcp"
+
+    dt = config.serialize(config.DICT)
+    assert (
+        dt.get("auto_pattern_default", {})
+        .get("auto_ip_default")
+        .get("auto")
+        .get("choice")
+        == "dhcp"
+    )
+
+    config.deserialize(dt)
+    assert config.auto_pattern_default.auto_ip_default.choice == "auto"
+    assert config.auto_pattern_default.auto_ip_default.auto.choice == "dhcp"

--- a/openapiart/tests/test_bundler.py
+++ b/openapiart/tests/test_bundler.py
@@ -6,7 +6,11 @@ def test_auto_feature(openapi_yaml):
         openapi_yaml.get("components").get("schemas")
     )
     for auto_field in property:
-        if len(auto_field.value) == 1 and "x-field-uid" in auto_field.value:
+        if (
+            len(auto_field.value) == 1
+            and "x-field-uid" in auto_field.value
+            or "$ref" in auto_field.value
+        ):
             continue
         assert auto_field.value.get("description") is not None
         assert auto_field.value.get("type") is not None

--- a/openapiart/tests/test_validate_x_field_pattern.py
+++ b/openapiart/tests/test_validate_x_field_pattern.py
@@ -28,6 +28,8 @@ def test_validate_pattern():
         "components.schemas.Config.properties.int_128.x-field-pattern property using x-field-pattern with format integer cannot have length greater than 64",
         "signed property can only be used if the format is set to integer in property components.schemas.Config.properties.signed_value_without_int.x-field-pattern",
         "invalid value 45 in components.schemas.Config.properties.wrong_int_signed_value.x-field-pattern, signed property can either be true or false",
+        "components.schemas.Config.properties.wrong_features_value.x-field-pattern has unspported feature abc , valid features are ['count', 'auto', 'metric_tags']",
+        "ref is a mandatory property in Pattern.Config.WrongAutoValue, when auto property is specified",
     ]
     with pytest.raises(Exception) as execinfo:
         create_openapi_artifacts(

--- a/openapiart/tests/test_validate_x_field_pattern.py
+++ b/openapiart/tests/test_validate_x_field_pattern.py
@@ -30,6 +30,8 @@ def test_validate_pattern():
         "invalid value 45 in components.schemas.Config.properties.wrong_int_signed_value.x-field-pattern, signed property can either be true or false",
         "components.schemas.Config.properties.wrong_features_value.x-field-pattern has unspported feature abc , valid features are ['count', 'auto', 'metric_tags']",
         "ref is a mandatory property in Pattern.Config.WrongAutoValue, when auto property is specified",
+        "default is a mandatory property in Pattern.Config.WrongAutoValue, when auto property is specified",
+        "only boolean values are allowed for default in Pattern.Config.WrongAutoDefaultValue",
     ]
     with pytest.raises(Exception) as execinfo:
         create_openapi_artifacts(

--- a/pkg/serdes_test.go
+++ b/pkg/serdes_test.go
@@ -384,3 +384,43 @@ func TestAutoHeirarchy(t *testing.T) {
 		openapiart.PatternAutoPatternAutoIpChoice.VALUES,
 		config.AutoPattern().AutoIp().Choice())
 }
+
+func TestAutoHeirarchyDefault(t *testing.T) {
+	config := openapiart.NewPrefixConfig()
+	config.SetA("asdf").SetB(12.2).SetC(1)
+	config.RequiredObject().SetEA(1).SetEB(2)
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternDefaultAutoIpDefaultChoice.AUTO,
+		config.AutoPatternDefault().AutoIpDefault().Choice())
+	assert.Equal(
+		t,
+		openapiart.AutoIpDefaultChoice.DHCP,
+		config.AutoPatternDefault().AutoIpDefault().Auto().Choice())
+
+	config.AutoPatternDefault().AutoIpDefault().Auto().Static()
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternDefaultAutoIpDefaultChoice.AUTO,
+		config.AutoPatternDefault().AutoIpDefault().Choice())
+	assert.Equal(
+		t,
+		openapiart.AutoIpDefaultChoice.STATIC,
+		config.AutoPatternDefault().AutoIpDefault().Auto().Choice())
+
+	config.AutoPatternDefault().AutoIpDefault().Auto().Dhcp()
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternDefaultAutoIpDefaultChoice.AUTO,
+		config.AutoPatternDefault().AutoIpDefault().Choice())
+	assert.Equal(
+		t,
+		openapiart.AutoIpDefaultChoice.DHCP,
+		config.AutoPatternDefault().AutoIpDefault().Auto().Choice())
+
+	config.AutoPatternDefault().AutoIpDefault().SetValues([]string{"10"})
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternDefaultAutoIpDefaultChoice.VALUES,
+		config.AutoPatternDefault().AutoIpDefault().Choice())
+}

--- a/pkg/serdes_test.go
+++ b/pkg/serdes_test.go
@@ -348,3 +348,39 @@ func TestAuto(t *testing.T) {
 		openapiart.PatternPrefixConfigAutoFieldTestChoiceEnum("auto"),
 		config.AutoFieldTest().Choice())
 }
+
+func TestAutoHeirarchy(t *testing.T) {
+	config := openapiart.NewPrefixConfig()
+	config.SetA("asdf").SetB(12.2).SetC(1)
+	config.RequiredObject().SetEA(1).SetEB(2)
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternAutoIpChoice.VALUE,
+		config.AutoPattern().AutoIp().Choice())
+
+	config.AutoPattern().AutoIp().Auto().Static()
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternAutoIpChoice.AUTO,
+		config.AutoPattern().AutoIp().Choice())
+	assert.Equal(
+		t,
+		openapiart.AutoIpOptionsChoice.STATIC,
+		config.AutoPattern().AutoIp().Auto().Choice())
+
+	config.AutoPattern().AutoIp().Auto().Dhcp()
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternAutoIpChoice.AUTO,
+		config.AutoPattern().AutoIp().Choice())
+	assert.Equal(
+		t,
+		openapiart.AutoIpOptionsChoice.DHCP,
+		config.AutoPattern().AutoIp().Auto().Choice())
+
+	config.AutoPattern().AutoIp().SetValues([]string{"10"})
+	assert.Equal(
+		t,
+		openapiart.PatternAutoPatternAutoIpChoice.VALUES,
+		config.AutoPattern().AutoIp().Choice())
+}


### PR DESCRIPTION
**Old Definition**

The old way of `auto` works the same way. i.e. by defining auto in features
example:
```yml
# initial definition
ipv4:
# other parameters
 dst:
  x-field-pattern:
    format: ipv4
    default: 0.0.0.0
    features: [auto, count]
  x-field-uid: 1

# after expansion by openapiart
Pattern.Ipv4Pattern.Ipv4.Dst:
  type: object
  properties:
    choice:
      type: string
      x-enum:
        value:
          x-field-uid: 2
        values:
          x-field-uid: 3
        auto:
          x-field-uid: 1
        increment:
          x-field-uid: 4
        decrement:
          x-field-uid: 5
      default: auto
      x-field-uid: 1
      enum:
      - value
      - values
      - auto
      - increment
      - decrement
    value:
      type: string
      x-field-uid: 2
      default: 0.0.0.0
      format: ipv4
    values:
      type: array
      items:
        type: string
        format: ipv4
      x-field-uid: 3
      default:
      - 0.0.0.0
    auto:
      description: |-
        The OTG implementation can provide a system generated
        value for this property. If the OTG is unable to generate a value
        the default value must be used.
      type: string
      x-field-uid: 4
      default: 0.0.0.0
      format: ipv4
    increment:
      $ref: '#/components/schemas/Pattern.Ipv4Pattern.Ipv4.Dst.Counter'
      x-field-uid: 5
    decrement:
      $ref: '#/components/schemas/Pattern.Ipv4Pattern.Ipv4.Dst.Counter'
      x-field-uid: 6
```

**New Definition**
The new definition allows auto to be hierarchical.
only valid property inside auto allowed till now is `ref `, which points to a object in the yaml and `default` which accepts a Boolean value to specify whether auto should be default choice or not.

```yml
# initial definition
ipv4:
# other properties
 dst:
  x-field-pattern:
    format: ipv4
    default: 0.0.0.0
    features: [auto, count]
    auto:
      $ref: "#/components/schemas/AutoIpOptions"
      default: false
  x-field-uid: 1

AutoIpOptions:
description: |-
  The OTG implementation can provide a system generated, value for this property. If the OTG is unable to generate a value, 
  the default value must be used.
type: object
  required: [choice]
  properties:
    choice:
      type: string
      x-field-uid: 1
      x-enum:
        static:
          x-field-uid: 1
        dhcp:
          x-field-uid: 2
 
# after expansion by openapiart
Pattern.Ipv4Pattern.Ipv4.Dst:
  type: object
  properties:
    choice:
      type: string
      x-enum:
        value:
          x-field-uid: 2
        values:
          x-field-uid: 3
        auto:
          x-field-uid: 1
        increment:
          x-field-uid: 4
        decrement:
          x-field-uid: 5
      default: auto
      x-field-uid: 1
      enum:
      - value
      - values
      - auto
      - increment
      - decrement
    value:
      type: string
      x-field-uid: 2
      default: 0.0.0.0
      format: ipv4
    values:
      type: array
      items:
        type: string
        format: ipv4
      x-field-uid: 3
      default:
      - 0.0.0.0
    auto:
      $ref: '#/components/schemas/AutoIpOptions'
      x-field-uid: 4
    increment:
      $ref: '#/components/schemas/Pattern.Ipv4Pattern.Ipv4.Dst.Counter'
      x-field-uid: 5
    decrement:
      $ref: '#/components/schemas/Pattern.Ipv4Pattern.Ipv4.Dst.Counter'
      x-field-uid: 6
```
 
**Go snippet to set hierarchical auto**
```go
Config.Ipv4().Dst().SetValue("1.1.1.2")
Config.Ipv4().Dst().Auto().Static()
Config.Ipv4().Dst().Auto().Dhcp()
```

**Python snippet to set hierarchical auto**
`Note:` python SDK exposes choice as of now unlike go SDK and also choices with no properties does not have a getter yet
```python
config.ipv4.dst.value = "1.1.1.2"
config.ipv4.dst.auto.choice = "static"
config.ipv4.dst.auto.choice = "dhcp"
```
 
 