### PR TITLE
adding ways to add component info for version mismatch error string

### DIFF
--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -726,6 +726,9 @@ class Generator:
                 self._write(2, "if self._version_check is None:")
                 self._write(3, "self._version_check = False")
                 self._write(2, "self._version_check_err = None")
+                self._write(2, "self._client_name = None")
+                self._write(2, "self._client_ver = None")
+                self._write(2, "self._server_name = None")
             else:
                 self._write(2, "pass")
 
@@ -823,6 +826,16 @@ class Generator:
         if not self._generate_version_api:
             return
 
+        # adding functionality for adding component info
+        self._write(
+            1,
+            "def set_component_info(self, client_name, client_version, server_name):",
+        )
+        self._write(2, "self._client_name = client_name")
+        self._write(2, "self._client_app_ver = client_version")
+        self._write(2, "self._server_name = server_name")
+        self._write()
+
         self._write(
             indent=1,
             line="""def _check_client_server_version_compatibility(
@@ -879,10 +892,16 @@ class Generator:
                 local.api_spec_version, remote.api_spec_version, "API spec"
             )
         except Exception as e:
-            msg = "client SDK version '{}' is not compatible with server SDK version '{}'".format(
-                local.sdk_version, remote.sdk_version
-            )
-            return Exception("{}: {}".format(msg, str(e))), None
+            if self._client_name is not None:
+                msg = "{} {} is not compatible with {} {}".format(
+                    self._client_name, self._client_app_ver, self._server_name, remote.app_version
+                )
+                return Exception(msg), None
+            else:
+                msg = "client SDK version '{}' is not compatible with server SDK version '{}'".format(
+                    local.sdk_version, remote.sdk_version
+                )
+                return Exception("{}: {}".format(msg, str(e))), None
 
         return None, None
 

--- a/openapiart/tests/grpcserver.py
+++ b/openapiart/tests/grpcserver.py
@@ -71,6 +71,7 @@ class OpenapiServicer(pb2_grpc.OpenapiServicer):
     def GetVersion(self, request, context):
         self._log("Executing GetVersion")
         v = op.api().get_local_version()
+        v.app_version = "1.2.3"
         response_200 = {"version": v.serialize(v.DICT)}
         res_obj = json_format.Parse(
             json.dumps(response_200), pb2.GetVersionResponse()

--- a/openapiart/tests/test_grpc_response.py
+++ b/openapiart/tests/test_grpc_response.py
@@ -111,5 +111,29 @@ def test_grpc_accept_yaml(grpc_api):
     grpc_api.set_config(s_obj)
 
 
+def test_version_mismatch_error(utils, grpc_api):
+    with open(utils.get_test_config_path("config.json")) as f:
+        payload = json.load(f)
+    try:
+        grpc_api.get_local_version().api_spec_version = "2.0.1"
+        grpc_api._version_check = True
+        grpc_api._version_check_err = None
+        grpc_api.set_component_info(
+            "keng-controller", "1.8.0", "protocol-engine"
+        )
+        grpc_api.set_config(payload)
+        raise Exception("expected version error")
+    except Exception as e:
+        assert (
+            str(e)
+            == "keng-controller 1.8.0 is not compatible with protocol-engine 1.2.3"
+        )
+    finally:
+        grpc_api.get_local_version().api_spec_version = "0.1.0"
+        grpc_api._version_check = False
+    #
+    # print(grpc_api.__dict__)
+
+
 if __name__ == "__main__":
     pytest.main(["-v", "-s", __file__])

--- a/pkg/mock_grpcserver_test.go
+++ b/pkg/mock_grpcserver_test.go
@@ -104,7 +104,7 @@ func (s *GrpcServer) GetConfig(ctx context.Context, req *empty.Empty) (*sanity.G
 }
 
 func (s *GrpcServer) GetVersion(ctx context.Context, req *empty.Empty) (*sanity.GetVersionResponse, error) {
-	ver, _ := openapiart.NewApi().GetLocalVersion().Marshal().ToProto()
+	ver, _ := openapiart.NewApi().GetLocalVersion().SetAppVersion("1.2.3").Marshal().ToProto()
 	resp := &sanity.GetVersionResponse{
 		Version: ver,
 	}

--- a/pkg/transport_test.go
+++ b/pkg/transport_test.go
@@ -421,3 +421,16 @@ func TestGrpcErrorStructUpdate(t *testing.T) {
 	assert.Equal(t, errSt.Kind(), openapiart.ErrorKind.VALIDATION)
 	assert.Equal(t, errSt.Errors()[0], "invalid1")
 }
+
+func TestVersionMismatchMsgWithComponentInfo(t *testing.T) {
+	api := apis[0]
+	config1 := NewFullyPopulatedPrefixConfig(api)
+	config1.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
+	api.SetVersionCompatibilityCheck(true)
+	api.GetLocalVersion().SetApiSpecVersion("2.0.1")
+	api.SetComponentInformation("keng-controller", "1.8.0", "protocol-engine")
+	_, err := api.SetConfig(config1)
+	assert.NotNil(t, err)
+	assert.Equal(t, err.Error(), "keng-controller 1.8.0 is not compatible with protocol-engine 1.2.3")
+	api.SetVersionCompatibilityCheck(false)
+}


### PR DESCRIPTION
new Api exposed SetComponentInformation(clientName, clientAppVersion, ServerName)

sample go test 
```go
func TestVersionMismatchMsgWithComponentInfo(t *testing.T) {
	api := apis[0]
	config1 := NewFullyPopulatedPrefixConfig(api)
	config1.SetResponse(openapiart.PrefixConfigResponse.STATUS_200)
	api.SetVersionCompatibilityCheck(true)
	api.GetLocalVersion().SetApiSpecVersion("2.0.1")
	api.SetComponentInformation("keng-controller", "1.8.0", "protocol-engine")
	_, err := api.SetConfig(config1)
	assert.NotNil(t, err)
	assert.Equal(t, err.Error(), "keng-controller 1.8.0 is not compatible with protocol-engine 1.2.3")
	api.SetVersionCompatibilityCheck(false)
}
```

sample python test
```py
def test_version_mismatch_error(utils, grpc_api):
    with open(utils.get_test_config_path("config.json")) as f:
        payload = json.load(f)
    try:
        grpc_api.get_local_version().api_spec_version = "2.0.1"
        grpc_api._version_check = True
        grpc_api._version_check_err = None
        grpc_api.set_component_info(
            "keng-controller", "1.8.0", "protocol-engine"
        )
        grpc_api.set_config(payload)
        raise Exception("expected version error")
    except Exception as e:
        assert (
            str(e)
            == "keng-controller 1.8.0 is not compatible with protocol-engine 1.2.3"
        )
    finally:
        grpc_api.get_local_version().api_spec_version = "0.1.0"
        grpc_api._version_check = False
```