### PR TITLE
Support pattern regex validation

### DIFF
--- a/openapiart/bundler.py
+++ b/openapiart/bundler.py
@@ -1096,7 +1096,6 @@ class Bundler(object):
                 "name": {
                     "description": "Name used to identify the metrics associated with the values applicable for configured offset and length inside corresponding header field",
                     "type": "string",
-                    "pattern": r"^[\sa-zA-Z0-9-_()><\[\]]+$",
                     "x-field-uid": metric_tags_auto_field.uid,
                 },
                 "offset": {

--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -1922,7 +1922,7 @@ class Generator:
                 if len(ref) == 0 and "maxLength" in yproperty:
                     pt.update({"maxLength": yproperty["maxLength"]})
                 if len(ref) == 0 and "pattern" in yproperty:
-                    pt.update({"pattern": "'%s'" % yproperty["pattern"]})
+                    pt.update({"pattern": "r'%s'" % yproperty["pattern"]})
                 if len(pt) > 0:
                     types.append((name, pt))
                 # TODO: restore behavior

--- a/openapiart/generator.py
+++ b/openapiart/generator.py
@@ -1894,6 +1894,8 @@ class Generator:
                         yproperty["minLength"] = item_prop.get("minLength")
                     if item_prop.get("maxLength") is not None:
                         yproperty["maxLength"] = item_prop.get("maxLength")
+                    if item_prop.get("pattern") is not None:
+                        yproperty["pattern"] = item_prop.get("pattern")
 
                 key = (
                     "itemformat"
@@ -1919,6 +1921,8 @@ class Generator:
                     pt.update({"minLength": yproperty["minLength"]})
                 if len(ref) == 0 and "maxLength" in yproperty:
                     pt.update({"maxLength": yproperty["maxLength"]})
+                if len(ref) == 0 and "pattern" in yproperty:
+                    pt.update({"pattern": "'%s'" % yproperty["pattern"]})
                 if len(pt) > 0:
                     types.append((name, pt))
                 # TODO: restore behavior

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -125,6 +125,7 @@ class FluentField(object):
         self.choice_with_no_prop = (
             []
         )  # maintain a list of choices with no properties for adding getter methods
+        self.pattern = None
 
 
 class OpenApiArtGo(OpenApiArtPlugin):
@@ -2580,6 +2581,7 @@ class OpenApiArtGo(OpenApiArtPlugin):
             field.hasminmaxlength = (
                 "minLength" in minmax_schema or "maxLength" in minmax_schema
             )
+            field.pattern = minmax_schema.get("pattern")
             if field.isEnum:
                 field.enums = (
                     self._get_parser("$..enum").find(property_schema)[0].value
@@ -2994,13 +2996,30 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     body=inner_body, name=field.name
                 )
         elif "string" in field.type:
+            if field.pattern:
+                inner_body += """
+                if !regexp.MustCompile(\"{pattern}\").MatchString({pointer}{value}) {{
+                    vObj.validationErrors = append(
+                    vObj.validationErrors,
+                    fmt.Sprintf(
+                        "{interface}.{name} should adhere to this regex pattern \'{pattern}\', but Got %s", {pointer}{value}))
+                }}
+                """.format(
+                    name=field.name,
+                    interface=new.interface,
+                    pattern=field.pattern,
+                    pointer="*" if field.isPointer else "",
+                    value="item"
+                    if field.isArray
+                    else "obj.obj.{name}".format(name=field.name),
+                )
             if field.hasminmaxlength and "string" in field.type:
                 line = []
                 if field.min_length is not None:
                     line.append("len({pointer}{value}) < {min_length}")
                 if field.max_length is not None:
                     line.append("len({pointer}{value}) > {max_length}")
-                inner_body = (
+                inner_body += (
                     "if "
                     + " || ".join(line)
                     + """ {{

--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -2998,11 +2998,11 @@ class OpenApiArtGo(OpenApiArtPlugin):
         elif "string" in field.type:
             if field.pattern:
                 inner_body += """
-                if !regexp.MustCompile(\"{pattern}\").MatchString({pointer}{value}) {{
+                if !regexp.MustCompile(`{pattern}`).MatchString({pointer}{value}) {{
                     vObj.validationErrors = append(
                     vObj.validationErrors,
                     fmt.Sprintf(
-                        "{interface}.{name} should adhere to this regex pattern \'{pattern}\', but Got %s", {pointer}{value}))
+                        "{interface}.{name} should adhere to this regex pattern '%s', but Got %s",  `{pattern}`, {pointer}{value}))
                 }}
                 """.format(
                     name=field.name,

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -193,7 +193,7 @@ components:
           type: string
           minLength: 3
           maxLength: 6
-          pattern: ^(.+)(#-#(.+))*$
+          pattern: ^([a-zA-Z0-9]+)(#-#[a-zA-Z0-9]+)*$
           x-field-uid: 33
         hex_slice:
           x-status:

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -193,6 +193,7 @@ components:
           type: string
           minLength: 3
           maxLength: 6
+          pattern: ^(.+)(#-#(.+))*$
           x-field-uid: 33
         hex_slice:
           x-status:
@@ -344,6 +345,10 @@ components:
           type: string
           format: binary
           x-field-uid: 63
+        str_regex:
+          type: string
+          pattern: ^(.+):(.+)$
+          x-field-uid: 64
 
     WObject:
       required: [w_name]

--- a/openapiart/tests/config/config.yaml
+++ b/openapiart/tests/config/config.yaml
@@ -193,7 +193,7 @@ components:
           type: string
           minLength: 3
           maxLength: 6
-          pattern: ^([a-zA-Z0-9]+)(#-#[a-zA-Z0-9]+)*$
+          pattern: ^[\sa-zA-Z0-9-_()><\[\]]+$
           x-field-uid: 33
         hex_slice:
           x-status:

--- a/openapiart/tests/test_formats.py
+++ b/openapiart/tests/test_formats.py
@@ -169,5 +169,22 @@ def test_int64_list(config, default_config):
         assert isinstance(d, int)
 
 
+def test_str_regex(config):
+    config.str_regex = "abc def"
+    try:
+        data = config.serialize("dict")
+    except Exception as e:
+        print(e)
+        assert (
+            "got abc def of type <class 'str'> , expected pattern '^(.+):(.+)$'"
+            in e.args[0]
+        )
+    config.str_regex = "abc:def"
+    data = config.serialize("dict")
+    print(data)
+    # to directly see the pattern
+    print("pattern is", config._TYPES["str_regex"]["pattern"])
+
+
 if __name__ == "__main__":
     pytest.main(["-v", "-s", __file__])

--- a/pkg/unit_test.go
+++ b/pkg/unit_test.go
@@ -1759,10 +1759,10 @@ func TestStringRegexError(t *testing.T) {
 	config.Name()
 	_, err := config.Marshal().ToYaml()
 	assert.NotNil(t, err)
-	assert.Contains(t, strings.ToLower(err.Error()), "prefixconfig.strlen should adhere to this regex pattern '^([a-za-z0-9]+)(#-#[a-za-z0-9]+)*$', but got a##d")
+	assert.Contains(t, strings.ToLower(err.Error()), "prefixconfig.strlen should adhere to this regex pattern '^[\\sa-za-z0-9-_()><\\[\\]]+$', but got a##d")
 	assert.Contains(t, strings.ToLower(err.Error()), "prefixconfig.strregex should adhere to this regex pattern '^(.+):(.+)$', but got a d")
 
-	config.SetStrLen("a#-#d")
+	config.SetStrLen("a[]d")
 	config.SetStrRegex("a:d")
 	_, err = config.Marshal().ToYaml()
 	assert.Nil(t, err)

--- a/pkg/unit_test.go
+++ b/pkg/unit_test.go
@@ -1744,6 +1744,31 @@ func TestArrayOfChoices(t *testing.T) {
 	assert.Equal(t, uint32(234), config2.Protocols().Items()[1].Rocev2().Items()[0].CnpDelayTimer())
 }
 
+func TestStringRegexError(t *testing.T) {
+	config := openapiart.NewPrefixConfig()
+	config.SetA("asdf").SetB(12.2).SetC(1).SetH(true).SetI([]byte{1, 0, 0, 1, 0, 0, 1, 1}).SetName("config")
+	config.SetSpace1(1)
+	config.RequiredObject().SetEA(1).SetEB(2)
+	config.SetIeee8021Qbb(true)
+	config.SetFullDuplex100Mb(2)
+	config.SetResponse("status_200")
+	config.SetStrLen("a##d")
+	config.SetStrRegex("a d")
+	config.StrLen()
+	config.Space1()
+	config.Name()
+	_, err := config.Marshal().ToYaml()
+	assert.NotNil(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "prefixconfig.strlen should adhere to this regex pattern '^([a-za-z0-9]+)(#-#[a-za-z0-9]+)*$', but got a##d")
+	assert.Contains(t, strings.ToLower(err.Error()), "prefixconfig.strregex should adhere to this regex pattern '^(.+):(.+)$', but got a d")
+
+	config.SetStrLen("a#-#d")
+	config.SetStrRegex("a:d")
+	_, err = config.Marshal().ToYaml()
+	assert.Nil(t, err)
+
+}
+
 // TODO: restore behavior
 // func TestDeprecationWarning(t *testing.T) {
 


### PR DESCRIPTION
Fixes #488 

The SDKs would not validate proper regex patterns for a string attribute both in python and go SDK.

Please have look at the unit tests which show-cases proper errors 
Python - https://github.com/open-traffic-generator/openapiart/pull/489/files#diff-f7a91928c87c1cc6eba37e26cf27444c61ddd38e37f302c44a0fbe1436954d16R172
Go - https://github.com/open-traffic-generator/openapiart/pull/489/files#diff-22e90fbde7cabc5856c55e0c7381696b83db4202165be4e9dfe3521c24a1d614R1747
