### PR TITLE
Preserve Go choice getter enum order

### DIFF
--- a/openapiart/openapiartgo.py
+++ b/openapiart/openapiartgo.py
@@ -2617,9 +2617,12 @@ class OpenApiArtGo(OpenApiArtPlugin):
                     field.enums.remove("unspecified")
                 if property_name == "choice":
                     prop_names.remove("choice")
-                    diff = set(field.enums).difference(set(prop_names))
-                    if len(diff) > 0:
-                        field.choice_with_no_prop = list(diff)
+                    prop_names_set = set(prop_names)
+                    field.choice_with_no_prop = [
+                        enum
+                        for enum in field.enums
+                        if enum not in prop_names_set
+                    ]
 
             if field.hasminmax:
                 field.min = (

--- a/openapiart/tests/test_go_choice_order.py
+++ b/openapiart/tests/test_go_choice_order.py
@@ -1,0 +1,105 @@
+import os
+
+from openapiart.openapiart import OpenApiArt as openapiart_class
+
+
+# Test that the enum getters are outputted in the same order
+# as the enum definition.  This was previously using a set,
+# which altered the order on each run so created unnecessary
+# diffs.  The real part of the schema that matters here is the
+# ChoiceHolder choice enum, everything else is plumbing.
+def test_go_choice_getters_preserve_enum_order(tmp_path):
+    api_file = tmp_path / "api.yaml"
+    api_file.write_text(
+        """
+paths:
+  /choice:
+    get:
+      operationId: get_choice
+      description: Gets the choice holder.
+      responses:
+        "200":
+          description: Choice holder response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChoiceHolder"
+          x-field-uid: 1
+        default:
+          description: Unexpected error.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+          x-field-uid: 2
+components:
+  schemas:
+    ChoiceHolder:
+      description: Object with choice enum values that have no backing properties.
+      type: object
+      properties:
+        choice:
+          description: Selects one of the no-property choices.
+          type: string
+          default: alpha
+          x-field-uid: 1
+          x-enum:
+            alpha:
+              x-field-uid: 1
+            beta:
+              x-field-uid: 2
+            gamma:
+              x-field-uid: 3
+            delta:
+              x-field-uid: 4
+    Error:
+      description: Error response generated while serving API request.
+      type: object
+      required:
+        - code
+        - errors
+      properties:
+        code:
+          description: Numeric status code.
+          type: integer
+          format: int32
+          x-field-uid: 1
+        errors:
+          description: Error messages.
+          type: array
+          items:
+            type: string
+          x-field-uid: 2
+""",
+        encoding="utf-8",
+    )
+    artifact_dir = tmp_path / "artifacts"
+
+    openapiart_class(
+        api_files=[
+            os.path.join(os.path.dirname(__file__), "api", "info.yaml"),
+            str(api_file),
+        ],
+        artifact_dir=str(artifact_dir),
+        extension_prefix="orderpkg",
+    ).GenerateGoSdk(
+        package_dir="github.com/open-traffic-generator/openapiart/orderpkg",
+        package_name="orderpkg",
+    )
+
+    generated = (tmp_path / "orderpkg" / "choice_holder.go").read_text(
+        encoding="utf-8"
+    )
+    # Get the offsets of Alpha, Beta, Gamma, Delta in the generated file.
+    getter_order = [
+        generated.index("func (obj *choiceHolder) Alpha()"),
+        generated.index("func (obj *choiceHolder) Beta()"),
+        generated.index("func (obj *choiceHolder) Gamma()"),
+        generated.index("func (obj *choiceHolder) Delta()"),
+    ]
+
+    # This assertion is a little obscure; it asserts that the ordering
+    # is preserved - Alpha is before Beta is before Gamma is before Delta.
+    # It will show just a list of integers being different, but the
+    # integers are offsets in the file, and they should be ordered.
+    assert getter_order == sorted(getter_order)


### PR DESCRIPTION
Build choice-with-no-property getters by filtering the enum list in model order instead of converting through a set. This keeps the generated Go output stable across multiple runs and versions. This reduces unnecessary diffs when looking at git history of a generated api (e.g., snappi).

Add a Go SDK generation test that verifies no-property choice getters are emitted in enum order.

Just as an example of the problem, see
https://github.com/open-traffic-generator/snappi/commit/d37e11c63edc923e81548dd943e4cf122d506d02
A very significant amount of this diff is the order of these getters. When there is no change in the model, there doesn't need to be a change in the generated code, reducing the size of diffs.