### PR TITLE
Stabilize generated requirements ordering

### DIFF
--- a/openapiart/requirements.py
+++ b/openapiart/requirements.py
@@ -1,8 +1,49 @@
 import os
 import sys
 import subprocess
+import re
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
+
+
+def _package_name(requirement):
+    match = re.match(r"\s*([A-Za-z0-9_.-]+)", requirement.split(";", 1)[0])
+    if match is None:
+        return None
+    return match.group(1).replace("_", "-").lower()
+
+
+def _without_packages(packages, ignored_packages):
+    ignored = {
+        name
+        for name in (_package_name(pkg) for pkg in ignored_packages)
+        if name is not None
+    }
+    return [pkg for pkg in packages if _package_name(pkg) not in ignored]
+
+
+def _resolve_required_packages(
+    new_packages, orig_packages, test_packages, ignored_packages=None
+):
+    if ignored_packages is None:
+        ignored_packages = []
+
+    new_packages = _without_packages(new_packages, ignored_packages)
+    orig_packages = _without_packages(orig_packages, ignored_packages)
+    test_packages = _without_packages(test_packages, ignored_packages)
+
+    required_names = {
+        name
+        for name in (_package_name(pkg) for pkg in new_packages)
+        if name is not None
+    }
+
+    final_packages = []
+    for pkg in orig_packages + test_packages:
+        name = _package_name(pkg)
+        if name in required_names and pkg not in final_packages:
+            final_packages.append(pkg)
+    return final_packages
 
 
 def generate_requirements(path, file_name=None):
@@ -25,32 +66,20 @@ def generate_requirements(path, file_name=None):
     not_required_pkgs = [
         "sanity",
         "typing_extensions",
-        "grpcio-tools~=1.44.0 ; python_version > '2.7'",
-        "grpcio-tools~=1.35.0 ; python_version == '2.7'",
     ]
 
     with open(os.path.join(base_dir, "requirements.txt"), "r") as fd:
         orig_packages = fd.read().splitlines()
-        orig_packages = list(set(orig_packages) - set(not_required_pkgs))
 
     with open(os.path.join(save_path, "requirements.txt"), "r") as fh:
         new_pkgs = fh.read().splitlines()
-        new_pkgs = list(set(new_pkgs) - set(not_required_pkgs))
 
     with open(os.path.join(base_dir, "test_requirements.txt"), "r") as fh:
         test_pkgs = fh.read().splitlines()
-        test_pkgs = list(set(test_pkgs) - set(not_required_pkgs))
 
-    final_pkgs = []
-    for n_pkg in new_pkgs:
-        for pkg in orig_packages:
-            if n_pkg in pkg and pkg not in final_pkgs:
-                final_pkgs.append(pkg)
-
-    for n_pkg in new_pkgs:
-        for pkg in test_pkgs:
-            if n_pkg in pkg and pkg not in final_pkgs:
-                final_pkgs.append(pkg)
+    final_pkgs = _resolve_required_packages(
+        new_pkgs, orig_packages, test_pkgs, not_required_pkgs
+    )
 
     with open(os.path.join(save_path, "requirements.txt"), "w+") as fh:
         fh.write("--prefer-binary")

--- a/openapiart/tests/test_requirements.py
+++ b/openapiart/tests/test_requirements.py
@@ -1,0 +1,47 @@
+from openapiart.requirements import _resolve_required_packages
+
+
+def test_resolve_required_packages_preserves_curated_order():
+    orig_packages = [
+        "PyYAML",
+        "requests",
+        "grpcio-tools~=1.80.0",
+        "protobuf~=6.33.6",
+        "grpcio~=1.80.0",
+        "typing_extensions>=4.0.0",
+    ]
+    test_packages = ["urllib3", "semantic_version", "sanity"]
+    new_packages = [
+        "semantic_version",
+        "grpcio",
+        "protobuf",
+        "requests",
+        "grpcio-tools",
+        "PyYAML",
+        "urllib3",
+        "typing_extensions",
+        "sanity",
+    ]
+
+    assert _resolve_required_packages(
+        new_packages,
+        orig_packages,
+        test_packages,
+        ignored_packages=["sanity", "typing_extensions"],
+    ) == [
+        "PyYAML",
+        "requests",
+        "grpcio-tools~=1.80.0",
+        "protobuf~=6.33.6",
+        "grpcio~=1.80.0",
+        "urllib3",
+        "semantic_version",
+    ]
+
+
+def test_resolve_required_packages_matches_package_names_not_substrings():
+    assert _resolve_required_packages(
+        new_packages=["grpcio"],
+        orig_packages=["grpcio-tools~=1.80.0", "grpcio~=1.80.0"],
+        test_packages=[],
+    ) == ["grpcio~=1.80.0"]


### PR DESCRIPTION
This fixes two observed behaviors in snappi's generated requirements.txt:
1. the order changes on every regeneration; this causes unnecessary repository churn;
2. they include grpcio-tools; the openapiart code has a mechanism to suppress this but it stopped working.

Generated Python SDK requirements were assembled by combining the output of pipreqs with openapiart's distributed requirements files. The implementation used sets to remove a few unwanted entries before walking the results. That made the final requirements.txt order depend on Python hash ordering, so regenerating a downstream SDK such as snappi could reorder requirements even when the actual dependency set had not changed.

Preserve the order from openapiart/requirements.txt and openapiart/test_requirements.txt instead. pipreqs is still used to decide which packages are imported by the generated package, but matching is now done by normalized package name rather than by iterating over unordered sets.

This also replaces the previous substring match:

    if n_pkg in pkg

That expression was intended to map pipreqs' unversioned names, such as "black" or "grpcio", back to the provided versioned requirement lines, such as "black==22.3.0" or "grpcio~=1.80.0". However, substring matching is too broad: "grpcio" also matches "grpcio-tools~=1.80.0". That can pull generator tooling into generated SDK runtime requirements even when the generated package only imports grpc.

Parse the package name from each requirement line and compare normalized names instead. This keeps the useful behavior of preserving the requirement specifier while avoiding accidental matches between similarly named packages.

The stale grpcio-tools suppressions are removed from not_required_pkgs. They referenced old exact requirement lines:

    grpcio-tools~=1.44.0 ; python_version > '2.7'
    grpcio-tools~=1.35.0 ; python_version == '2.7'

Those entries no longer match the current grpcio-tools specification in openapiart/requirements.txt, and they are no longer needed to protect against grpcio accidentally selecting grpcio-tools. If a generated package actually imports grpc_tools in the future, that should be handled deliberately rather than hidden behind stale exact-line filters.

Add focused tests for deterministic ordering and exact package-name matching.